### PR TITLE
Add accessibility to input's error message

### DIFF
--- a/src/components/MaText/MaText.vue
+++ b/src/components/MaText/MaText.vue
@@ -23,7 +23,14 @@
       />
       <slot name="inputSibling" />
     </div>
-    <div v-if="hasError" class="ma-text__error-message" v-text="errorMessage" />
+    <div
+      v-if="hasError"
+      class="ma-text__error-message"
+      aria-live="polite"
+      aria-atomic="true"
+      role="alert"
+      v-text="errorMessage"
+    />
   </div>
 </template>
 


### PR DESCRIPTION
Still need to test this in a 'real world' project. Works fine in storybook, but... I haven't been able to make the `npm-link-shared` work :( 