### PR TITLE
Update colors to match Design System

### DIFF
--- a/src/assets/icons/warning.svg
+++ b/src/assets/icons/warning.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 19" fill="#945d00">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 19" fill="#f5d154">
 <path d="M0,19H22L11,0Zm12-3H10V14h2Zm0-4H10V8h2Z"/>
 </svg>

--- a/src/components/MaAlert/MaAlert.scss
+++ b/src/components/MaAlert/MaAlert.scss
@@ -1,6 +1,6 @@
 .alert-banner {
   display: flex;
-  color: get-color(ink);
+  color: get-color(gray, darkest);
 
   &--small {
     padding: rem(4px);

--- a/src/components/MaAlert/MaAlert.scss
+++ b/src/components/MaAlert/MaAlert.scss
@@ -1,5 +1,6 @@
 .alert-banner {
   display: flex;
+  color: get-color(ink);
 
   &--small {
     padding: rem(4px);
@@ -61,7 +62,6 @@
   }
 
   &__text {
-    @include font-weight(medium);
     margin: 0;
     width: 100%;
   }
@@ -75,22 +75,22 @@
   }
 
   &--error {
+    border: 1px solid get-color(red);
     background-color: get-color(red, light);
-    color: get-color(red);
   }
 
   &--info {
+    border: 1px solid get-color(blue);
     background-color: get-color(blue, light);
-    color: get-color(blue);
   }
 
   &--success {
+    border: 1px solid get-color(green);
     background-color: get-color(green, light);
-    color: get-color(green);
   }
 
   &--warning {
+    border: 1px solid get-color(yellow);
     background-color: get-color(yellow, light);
-    color: get-color(yellow);
   }
 }

--- a/src/components/MaAlert/MaAlert.scss
+++ b/src/components/MaAlert/MaAlert.scss
@@ -75,22 +75,22 @@
   }
 
   &--error {
-    background-color: get-color('pippin');
-    color: get-color('crimson');
+    background-color: get-color(red, light);
+    color: get-color(red);
   }
 
   &--info {
-    background-color: get-color('humming-bird');
-    color: get-color('calypso');
+    background-color: get-color(blue, light);
+    color: get-color(blue);
   }
 
   &--success {
-    background-color: get-color('primrose');
-    color: get-color('japanese-laurel');
+    background-color: get-color(green, light);
+    color: get-color(green);
   }
 
   &--warning {
-    background-color: get-color('peach-cream');
-    color: get-color('brown');
+    background-color: get-color(yellow, light);
+    color: get-color(yellow);
   }
 }

--- a/src/components/MaAlert/MaAlert.scss
+++ b/src/components/MaAlert/MaAlert.scss
@@ -1,6 +1,6 @@
 .alert-banner {
   display: flex;
-  color: get-color(gray, darkest);
+  color: get-color(gray, darker);
 
   &--small {
     padding: rem(4px);

--- a/src/components/MaButton/MaButton.scss
+++ b/src/components/MaButton/MaButton.scss
@@ -15,12 +15,12 @@
     cursor: not-allowed;
 
     &:not(.ma-button--loading) {
-      border-color: get-color('boulder');
-      color: get-color('boulder');
+      border-color: get-color(sky);
+      color: get-color(sky);
 
       &:not(.ma-button--secondary):not(.ma-button--no-background):not(.ma-button--white) {
-        background: get-color('boulder');
-        color: get-color('white');
+        background: get-color(sky);
+        color: get-color(white);
       }
     }
   }
@@ -43,92 +43,92 @@
     border: 0;
     padding: 0;
     width: auto;
-    color: get-color('dark-hot-pink');
+    color: get-color(pink);
 
     &:hover:not(:disabled),
     &:active:not(:disabled) {
-      color: darken(get-color('dark-hot-pink'), 10%);
+      color: darken(get-color(pink), 10%);
     }
   }
 
   &--primary {
-    background-color: get-color('dark-hot-pink');
-    color: get-color('white');
+    background-color: get-color(pink);
+    color: get-color(white);
 
     &:focus {
-      outline: 2px solid get-color('classic-rose');
+      outline: 2px solid get-color(pink, light);
       outline-offset: 0;
     }
 
     &:hover:not(:disabled),
     &:active:not(:disabled) {
-      background-color: darken(get-color('dark-hot-pink'), 10%);
-      color: get-color('white');
+      background-color: darken(get-color(pink), 10%);
+      color: get-color(white);
     }
 
     &.ma-button--rounded {
-      box-shadow: 0 2px 3px 2px get-color('shadow-medium');
+      box-shadow: 0 2px 3px 2px $shadow-medium;
     }
   }
 
   &--secondary {
-    border-color: get-color('dark-hot-pink');
+    border-color: get-color(pink);
     background-color: transparent;
-    color: get-color('dark-hot-pink');
+    color: get-color(pink);
 
     &:focus {
-      outline: 2px solid get-color('classic-rose');
+      outline: 2px solid get-color(pink, light);
       outline-offset: 0;
     }
 
     &:hover:not(:disabled),
     &:active:not(:disabled) {
-      background-color: get-color('dark-hot-pink');
-      color: get-color('white');
+      background-color: get-color(pink);
+      color: get-color(white);
     }
 
     &.ma-button--rounded {
       border-color: transparent;
       background-color: transparent;
-      color: get-color('dark-hot-pink');
+      color: get-color(pink);
 
       &:hover:not(:disabled),
       &:active:not(:disabled),
       &.ma-button--loading {
-        border-color: lighten(get-color('dark-hot-pink'), 50%);
-        background-color: lighten(get-color('dark-hot-pink'), 50%);
-        color: get-color('dark-hot-pink');
+        border-color: lighten(get-color(pink), 50%);
+        background-color: lighten(get-color(pink), 50%);
+        color: get-color(pink);
       }
     }
   }
 
   &--white {
-    border-color: get-color('white');
+    border-color: get-color(white);
     background-color: transparent;
-    color: get-color('white');
+    color: get-color(white);
 
     &:focus {
-      outline: 2px solid get-color('classic-rose');
+      outline: 2px solid get-color(pink, light);
       outline-offset: 0;
     }
 
     &:hover:not(:disabled),
     &:active:not(:disabled) {
-      background-color: get-color('tango');
-      color: get-color('white');
+      background-color: get-color(orange);
+      color: get-color(white);
     }
 
     &.ma-button--rounded {
       border-color: transparent;
       background-color: transparent;
-      color: get-color('white');
+      color: get-color(white);
 
       &:hover:not(:disabled),
       &:active:not(:disabled),
       &.ma-button--loading {
-        border-color: lighten(get-color('white'), 50%);
-        background-color: lighten(get-color('white'), 50%);
-        color: get-color('white');
+        border-color: lighten(get-color(white), 50%);
+        background-color: lighten(get-color(white), 50%);
+        color: get-color(white);
       }
     }
   }
@@ -136,16 +136,16 @@
   &--gradient {
     background-image: linear-gradient(
       to right,
-      get-color('dark-hot-pink') 0%,
-      get-color('tango') 40%,
-      get-color('selective-yellow') 50%,
-      get-color('dark-hot-pink') 100%
+      get-color(pink) 0%,
+      get-color(orange) 40%,
+      get-color(yellow, dark) 50%,
+      get-color(pink) 100%
     );
     background-size: 200% auto;
-    color: get-color('white');
+    color: get-color(white);
 
     &:focus {
-      outline: 2px solid get-color('classic-rose');
+      outline: 2px solid get-color(pink, light);
       outline-offset: 0;
     }
 

--- a/src/components/MaButton/MaButton.scss
+++ b/src/components/MaButton/MaButton.scss
@@ -15,11 +15,11 @@
     cursor: not-allowed;
 
     &:not(.ma-button--loading) {
-      border-color: get-color(sky);
-      color: get-color(sky);
+      border-color: get-color(gray);
+      color: get-color(gray);
 
       &:not(.ma-button--secondary):not(.ma-button--no-background):not(.ma-button--white) {
-        background: get-color(sky);
+        background: get-color(gray);
         color: get-color(white);
       }
     }

--- a/src/components/MaButton/components/MaButtonSpinner.scss
+++ b/src/components/MaButton/components/MaButtonSpinner.scss
@@ -18,13 +18,13 @@ $duration: 1.4s;
 .ma-button-spinner__path {
   transform-origin: center;
   animation: dash $duration ease-in-out infinite;
-  stroke: get-color('white');
+  stroke: get-color(white);
   stroke-dasharray: $offset;
   stroke-dashoffset: 0;
 
   .ma-button--secondary &,
   .ma-button--no-background & {
-    stroke: get-color('dark-hot-pink');
+    stroke: get-color(pink);
   }
 }
 

--- a/src/components/MaCard/MaCard.scss
+++ b/src/components/MaCard/MaCard.scss
@@ -2,7 +2,7 @@
   padding: rem(24px);
 
   &--gray {
-    background-color: get-color(gray, lighter);
+    background-color: get-color(brown, light);
   }
 
   &--white {

--- a/src/components/MaCard/MaCard.scss
+++ b/src/components/MaCard/MaCard.scss
@@ -2,12 +2,12 @@
   padding: rem(24px);
 
   &--gray {
-    background-color: get-color('concrete');
+    background-color: get-color(sky, light);
   }
 
   &--white {
-    box-shadow: 0 0 6px 2px get-color('shadow-light');
-    background-color: get-color('white');
+    box-shadow: 0 0 6px 2px $shadow-light;
+    background-color: get-color(white);
   }
 
   &--has-padding-top {

--- a/src/components/MaCard/MaCard.scss
+++ b/src/components/MaCard/MaCard.scss
@@ -2,7 +2,7 @@
   padding: rem(24px);
 
   &--gray {
-    background-color: get-color(gray, light);
+    background-color: get-color(gray, lighter);
   }
 
   &--white {

--- a/src/components/MaCard/MaCard.scss
+++ b/src/components/MaCard/MaCard.scss
@@ -2,7 +2,7 @@
   padding: rem(24px);
 
   &--gray {
-    background-color: get-color(sky, light);
+    background-color: get-color(gray, light);
   }
 
   &--white {

--- a/src/components/MaDatagrid/MaDatagrid.scss
+++ b/src/components/MaDatagrid/MaDatagrid.scss
@@ -15,7 +15,7 @@
     border: 0;
     padding: 0;
     vertical-align: baseline;
-    color: get-color('tundora');
+    color: get-color(ink, light);
     font-size: 100%;
   }
 
@@ -58,8 +58,8 @@
       align-items: center;
       margin-bottom: 1rem;
       border-radius: rem(4px);
-      box-shadow: 0 0 6.4px 4px get-color('shadow-light');
-      background-color: get-color('white');
+      box-shadow: 0 0 6.4px 4px $shadow-light;
+      background-color: get-color(white);
 
       &:last-child {
         margin-bottom: 0;

--- a/src/components/MaDatagrid/MaDatagrid.scss
+++ b/src/components/MaDatagrid/MaDatagrid.scss
@@ -15,7 +15,7 @@
     border: 0;
     padding: 0;
     vertical-align: baseline;
-    color: get-color(ink, light);
+    color: get-color(gray, dark);
     font-size: 100%;
   }
 

--- a/src/components/MaDatagrid/components/MaDatagridArrow.vue
+++ b/src/components/MaDatagrid/components/MaDatagridArrow.vue
@@ -25,6 +25,6 @@ export default {
 
 <style lang="scss" scoped>
 .polygon {
-  fill: get-color('dark-hot-pink');
+  fill: get-color(pink);
 }
 </style>

--- a/src/components/MaDatagrid/components/MaDatagridLoader.scss
+++ b/src/components/MaDatagrid/components/MaDatagridLoader.scss
@@ -11,9 +11,9 @@
     mix-blend-mode: overlay;
     background: linear-gradient(
       to right,
-      lighten(get-color('black'), 80%) 2%,
-      lighten(get-color('black'), 40%) 18%,
-      lighten(get-color('black'), 80%) 33%
+      lighten(get-color(black), 80%) 2%,
+      lighten(get-color(black), 40%) 18%,
+      lighten(get-color(black), 80%) 33%
     );
     background-size: 50%;
     width: 100%;
@@ -37,7 +37,7 @@
 .loader-item {
   margin-bottom: rem(8px);
   border-radius: rem(16px);
-  background: lighten(get-color('black'), 85%);
+  background: lighten(get-color(black), 85%);
   height: rem(8px);
 
   &:last-child {

--- a/src/components/MaGridContainer/stories.scss
+++ b/src/components/MaGridContainer/stories.scss
@@ -11,7 +11,7 @@
   justify-content: center;
   border: 2px;
   padding: 1rem;
-  color: get-color('white');
+  color: get-color(white);
 
   &.px0 {
     padding-right: 0;
@@ -22,19 +22,19 @@
 .ma-grid-row {
   &:nth-child(odd) {
     .content {
-      border-color: get-darken-color('picton-blue', 20%);
-      background-color: get-darken-color('picton-blue', 20%);
+      border-color: darken(get-color(blue), 20%);
+      background-color: darken(get-color(blue), 20%);
 
       &.pink {
-        background-color: get-color('dark-hot-pink');
+        background-color: get-color(pink);
       }
     }
   }
 
   &:nth-child(even) {
     .content {
-      border-color: get-color('picton-blue');
-      background-color: get-color('picton-blue');
+      border-color: get-color(blue);
+      background-color: get-color(blue);
     }
   }
 }

--- a/src/components/MaOption/MaOption.scss
+++ b/src/components/MaOption/MaOption.scss
@@ -13,7 +13,7 @@
       &:focus,
       &:checked {
         & ~ .description {
-          border-color: get-color('dark-hot-pink');
+          border-color: get-color(pink);
         }
       }
 
@@ -35,7 +35,7 @@
 
         &::after {
           border-color: transparent;
-          border-right-color: get-color('dark-hot-pink');
+          border-right-color: get-color(pink);
         }
       }
     }
@@ -48,9 +48,9 @@
     }
 
     & ~ .description {
-      border-color: get-color('alto');
-      background-color: get-color('wild-sand');
-      color: get-color('scorpion');
+      border-color: get-color(sky, light);
+      background-color: get-color(white);
+      color: get-color(sky);
     }
   }
 
@@ -88,10 +88,10 @@
 
   .description {
     flex: 1;
-    border: 1px solid get-color('alto');
+    border: 1px solid get-color(sky, light);
     border-radius: rem(8px);
-    box-shadow: 0 0 8px 6px get-color('shadow-light');
-    background-color: get-color('white');
+    box-shadow: 0 0 8px 6px $shadow-light;
+    background-color: get-color(white);
     padding: rem(24px);
   }
 }

--- a/src/components/MaOption/MaOption.scss
+++ b/src/components/MaOption/MaOption.scss
@@ -49,7 +49,7 @@
 
     & ~ .description {
       border-color: get-color(gray, light);
-      background-color: get-color(gray, lightest);
+      background-color: get-color(gray, lighter);
       color: get-color(gray);
     }
   }

--- a/src/components/MaOption/MaOption.scss
+++ b/src/components/MaOption/MaOption.scss
@@ -49,7 +49,7 @@
 
     & ~ .description {
       border-color: get-color(gray, light);
-      background-color: get-color(gray, lighter);
+      background-color: get-color(brown, light);
       color: get-color(gray);
     }
   }

--- a/src/components/MaOption/MaOption.scss
+++ b/src/components/MaOption/MaOption.scss
@@ -48,9 +48,9 @@
     }
 
     & ~ .description {
-      border-color: get-color(sky, light);
+      border-color: get-color(gray, light);
       background-color: get-color(white);
-      color: get-color(sky);
+      color: get-color(gray);
     }
   }
 
@@ -88,7 +88,7 @@
 
   .description {
     flex: 1;
-    border: 1px solid get-color(sky, light);
+    border: 1px solid get-color(gray, light);
     border-radius: rem(8px);
     box-shadow: 0 0 8px 6px $shadow-light;
     background-color: get-color(white);

--- a/src/components/MaOption/MaOption.scss
+++ b/src/components/MaOption/MaOption.scss
@@ -49,7 +49,7 @@
 
     & ~ .description {
       border-color: get-color(gray, light);
-      background-color: get-color(white);
+      background-color: get-color(gray, lightest);
       color: get-color(gray);
     }
   }

--- a/src/components/MaOption/MaOptionCheckbox.scss
+++ b/src/components/MaOption/MaOptionCheckbox.scss
@@ -4,8 +4,8 @@
     top: rem(2px);
     left: 0;
     transition: border 0.4s, background-color 0.33s;
-    border: 1px solid get-color('alto');
-    background-color: get-color('white');
+    border: 1px solid get-color(sky, light);
+    background-color: get-color(white);
     width: rem(16px);
     height: rem(16px);
   }
@@ -13,12 +13,12 @@
   .description {
     padding-left: rem(22px);
     line-height: 1.3;
-    color: get-color('tundora');
+    color: get-color(ink, light);
   }
 
   .input {
     &:hover ~ .indicator {
-      border: 1px solid get-color('dark-hot-pink');
+      border: 1px solid get-color(pink);
     }
 
     &:checked ~ .indicator,
@@ -31,11 +31,11 @@
     }
 
     &:checked ~ .indicator {
-      background-color: get-color('dark-hot-pink');
+      background-color: get-color(pink);
     }
 
     &:disabled ~ .indicator {
-      background-color: get-color('boulder');
+      background-color: get-color(sky);
       cursor: not-allowed;
     }
 

--- a/src/components/MaOption/MaOptionCheckbox.scss
+++ b/src/components/MaOption/MaOptionCheckbox.scss
@@ -4,7 +4,7 @@
     top: rem(2px);
     left: 0;
     transition: border 0.4s, background-color 0.33s;
-    border: 1px solid get-color(sky, light);
+    border: 1px solid get-color(gray, light);
     background-color: get-color(white);
     width: rem(16px);
     height: rem(16px);
@@ -13,7 +13,7 @@
   .description {
     padding-left: rem(22px);
     line-height: 1.3;
-    color: get-color(ink, light);
+    color: get-color(gray, dark);
   }
 
   .input {
@@ -35,7 +35,7 @@
     }
 
     &:disabled ~ .indicator {
-      background-color: get-color(sky);
+      background-color: get-color(gray);
       cursor: not-allowed;
     }
 

--- a/src/components/MaOption/MaOptionRadio.scss
+++ b/src/components/MaOption/MaOptionRadio.scss
@@ -5,9 +5,9 @@
     position: relative;
     flex-shrink: 0;
     margin-top: 1px;
-    border: 1px solid get-color('gray');
+    border: 1px solid get-color(sky);
     border-radius: 50%;
-    background-color: get-color('white');
+    background-color: get-color(white);
     cursor: pointer;
     width: rem(16px);
     height: rem(16px);
@@ -25,7 +25,7 @@
     }
 
     &:disabled ~ .indicator {
-      background-color: get-color('concrete');
+      background-color: get-color(sky, light);
     }
 
     &:not(:disabled) {
@@ -34,7 +34,7 @@
       &:checked,
       &:focus {
         ~ .indicator {
-          border-color: get-color('dark-hot-pink');
+          border-color: get-color(pink);
         }
       }
 
@@ -48,7 +48,7 @@
           bottom: 2px;
           left: 2px;
           border-radius: 50%;
-          background-color: get-color('dark-hot-pink');
+          background-color: get-color(pink);
           content: '';
         }
       }

--- a/src/components/MaOption/MaOptionRadio.scss
+++ b/src/components/MaOption/MaOptionRadio.scss
@@ -25,7 +25,7 @@
     }
 
     &:disabled ~ .indicator {
-      background-color: get-color(gray, lighter);
+      background-color: get-color(brown, light);
     }
 
     &:not(:disabled) {

--- a/src/components/MaOption/MaOptionRadio.scss
+++ b/src/components/MaOption/MaOptionRadio.scss
@@ -25,7 +25,7 @@
     }
 
     &:disabled ~ .indicator {
-      background-color: get-color(gray, light);
+      background-color: get-color(gray, lighter);
     }
 
     &:not(:disabled) {

--- a/src/components/MaOption/MaOptionRadio.scss
+++ b/src/components/MaOption/MaOptionRadio.scss
@@ -5,7 +5,7 @@
     position: relative;
     flex-shrink: 0;
     margin-top: 1px;
-    border: 1px solid get-color(sky);
+    border: 1px solid get-color(gray);
     border-radius: 50%;
     background-color: get-color(white);
     cursor: pointer;
@@ -25,7 +25,7 @@
     }
 
     &:disabled ~ .indicator {
-      background-color: get-color(sky, light);
+      background-color: get-color(gray, light);
     }
 
     &:not(:disabled) {

--- a/src/components/MaPagination/MaPagination.scss
+++ b/src/components/MaPagination/MaPagination.scss
@@ -30,5 +30,5 @@
   justify-content: center;
   padding-bottom: rem(8px);
   text-align: center;
-  color: get-color(ink, light);
+  color: get-color(gray, dark);
 }

--- a/src/components/MaPagination/MaPagination.scss
+++ b/src/components/MaPagination/MaPagination.scss
@@ -5,7 +5,7 @@
 }
 
 .ma-pagination__button {
-  box-shadow: 0 2px 3px 2px get-color('shadow-light');
+  box-shadow: 0 2px 3px 2px $shadow-light;
   min-width: 2.3rem;
   height: 2.3rem;
 }
@@ -30,5 +30,5 @@
   justify-content: center;
   padding-bottom: rem(8px);
   text-align: center;
-  color: get-color('tundora');
+  color: get-color(ink, light);
 }

--- a/src/components/MaPill/MaPill.scss
+++ b/src/components/MaPill/MaPill.scss
@@ -19,7 +19,7 @@
 
   &--orange {
     background-color: get-color(yellow, light);
-    color: get-color(yellow);
+    color: get-color(orange);
   }
 
   &--gray {

--- a/src/components/MaPill/MaPill.scss
+++ b/src/components/MaPill/MaPill.scss
@@ -23,13 +23,13 @@
   }
 
   &--gray {
-    border: 1px solid get-color(sky);
-    background-color: get-color(sky, light);
-    color: get-color(ink, light);
+    border: 1px solid get-color(gray);
+    background-color: get-color(gray, light);
+    color: get-color(gray, dark);
   }
 
   &--dark {
-    background-color: get-color(ink, light);
+    background-color: get-color(gray, dark);
     color: get-color(white);
   }
 

--- a/src/components/MaPill/MaPill.scss
+++ b/src/components/MaPill/MaPill.scss
@@ -13,17 +13,17 @@
   }
 
   &--red {
-    background-color: get-color(pink, light);
-    color: get-color(pink);
+    background-color: get-color(red, light);
+    color: get-color(red);
   }
 
   &--orange {
-    background-color: get-color(yellow, dark);
-    color: get-color(orange);
+    background-color: get-color(yellow, light);
+    color: get-color(yellow);
   }
 
   &--gray {
-    border: 1px solid get-color(sky, light);
+    border: 1px solid get-color(sky);
     background-color: get-color(sky, light);
     color: get-color(ink, light);
   }

--- a/src/components/MaPill/MaPill.scss
+++ b/src/components/MaPill/MaPill.scss
@@ -8,33 +8,33 @@
   font-size: rem(14px);
 
   &--green {
-    background-color: get-color('primrose');
-    color: get-color('japanese-laurel');
+    background-color: get-color(green, light);
+    color: get-color(green);
   }
 
   &--red {
-    background-color: get-color('pippin');
-    color: get-color('crimson');
+    background-color: get-color(pink, light);
+    color: get-color(pink);
   }
 
   &--orange {
-    background-color: get-color('peach-cream');
-    color: get-color('brown');
+    background-color: get-color(yellow, dark);
+    color: get-color(orange);
   }
 
   &--gray {
-    border: 1px solid get-color('alto');
-    background-color: get-color('concrete');
-    color: get-color('tundora');
+    border: 1px solid get-color(sky, light);
+    background-color: get-color(sky, light);
+    color: get-color(ink, light);
   }
 
   &--dark {
-    background-color: get-color('tundora');
-    color: get-color('white');
+    background-color: get-color(ink, light);
+    color: get-color(white);
   }
 
   &--blue {
-    background-color: get-color('humming-bird');
-    color: get-color('calypso');
+    background-color: get-color(blue, light);
+    color: get-color(blue);
   }
 }

--- a/src/components/MaRange/MaRange.scss
+++ b/src/components/MaRange/MaRange.scss
@@ -11,27 +11,27 @@ $ma-range-bullet-size: rem(4px);
   &::after {
     display: block;
     border-radius: $ma-range-radius;
-    background-color: get-color('alto');
+    background-color: get-color(sky, light);
     width: 100%;
     height: $ma-range-height;
     content: '';
   }
 
   &__label {
-    color: get-color('tundora');
+    color: get-color(ink, light);
   }
 
   &__step {
     position: absolute;
     cursor: pointer;
     padding-top: rem(21px);
-    color: get-color('boulder');
+    color: get-color(sky);
     user-select: none;
   }
 
   &__step--active {
     @include font-weight(medium);
-    color: get-color('tundora');
+    color: get-color(ink, light);
   }
 
   &__native-element {
@@ -51,9 +51,9 @@ $ma-range-bullet-size: rem(4px);
     display: inline-block;
     position: absolute;
     transition: $ma-range-transition;
-    border: 2px solid get-color('dark-hot-pink');
+    border: 2px solid get-color(pink);
     border-radius: 50%;
-    background: get-color('white');
+    background: get-color(white);
     width: $ma-range-height;
     height: $ma-range-height;
   }
@@ -65,11 +65,7 @@ $ma-range-bullet-size: rem(4px);
     left: 0;
     transition: $ma-range-transition;
     border-radius: $ma-range-radius;
-    background: linear-gradient(
-      to right,
-      get-color('buttercup'),
-      get-color('dark-hot-pink')
-    );
+    background: linear-gradient(to right, get-color(orange), get-color(pink));
     height: $ma-range-height;
   }
 
@@ -80,7 +76,7 @@ $ma-range-bullet-size: rem(4px);
     left: 0%;
     z-index: 2;
     border-radius: 50%;
-    background: get-color('white');
+    background: get-color(white);
     cursor: pointer;
     width: $ma-range-bullet-size;
     height: $ma-range-bullet-size;

--- a/src/components/MaRange/MaRange.scss
+++ b/src/components/MaRange/MaRange.scss
@@ -11,27 +11,27 @@ $ma-range-bullet-size: rem(4px);
   &::after {
     display: block;
     border-radius: $ma-range-radius;
-    background-color: get-color(sky, light);
+    background-color: get-color(gray, light);
     width: 100%;
     height: $ma-range-height;
     content: '';
   }
 
   &__label {
-    color: get-color(ink, light);
+    color: get-color(gray, dark);
   }
 
   &__step {
     position: absolute;
     cursor: pointer;
     padding-top: rem(21px);
-    color: get-color(sky);
+    color: get-color(gray);
     user-select: none;
   }
 
   &__step--active {
     @include font-weight(medium);
-    color: get-color(ink, light);
+    color: get-color(gray, dark);
   }
 
   &__native-element {

--- a/src/components/MaSelect/MaSelect.scss
+++ b/src/components/MaSelect/MaSelect.scss
@@ -32,7 +32,7 @@
     }
 
     &:disabled {
-      background-color: get-color(gray, lighter);
+      background-color: get-color(brown, light);
       color: get-color(gray);
       pointer-events: none;
     }

--- a/src/components/MaSelect/MaSelect.scss
+++ b/src/components/MaSelect/MaSelect.scss
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   width: 100%;
-  color: get-color(ink, light);
+  color: get-color(gray, dark);
   font-size: rem(16px);
 
   &__label {
@@ -12,7 +12,7 @@
   &__field {
     -webkit-appearance: none;
     transition: border 0.2s ease;
-    border: 1px solid get-color(sky, light);
+    border: 1px solid get-color(gray, light);
     border-radius: 0;
     background-color: get-color(white);
     background-image: url('../../assets/icons/arrow.svg');
@@ -22,7 +22,7 @@
     padding: 0 rem(32px) 0 rem(8px);
     width: 100%;
     height: rem(36px);
-    color: get-color(ink, light);
+    color: get-color(gray, dark);
     font-size: rem(16px);
 
     &:focus {
@@ -32,8 +32,8 @@
     }
 
     &:disabled {
-      background-color: get-color(sky, light);
-      color: get-color(sky);
+      background-color: get-color(gray, light);
+      color: get-color(gray);
       pointer-events: none;
     }
 

--- a/src/components/MaSelect/MaSelect.scss
+++ b/src/components/MaSelect/MaSelect.scss
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   width: 100%;
-  color: get-color('tundora');
+  color: get-color(ink, light);
   font-size: rem(16px);
 
   &__label {
@@ -12,9 +12,9 @@
   &__field {
     -webkit-appearance: none;
     transition: border 0.2s ease;
-    border: 1px solid get-color('alto');
+    border: 1px solid get-color(sky, light);
     border-radius: 0;
-    background-color: get-color('white');
+    background-color: get-color(white);
     background-image: url('../../assets/icons/arrow.svg');
     background-position: calc(100% - 12px) 50%;
     background-repeat: no-repeat;
@@ -22,33 +22,33 @@
     padding: 0 rem(32px) 0 rem(8px);
     width: 100%;
     height: rem(36px);
-    color: get-color('tundora');
+    color: get-color(ink, light);
     font-size: rem(16px);
 
     &:focus {
-      outline: 2px solid get-color('classic-rose');
+      outline: 2px solid get-color(pink, light);
       outline-offset: 0;
-      border: 1px solid get-color('dark-hot-pink');
+      border: 1px solid get-color(pink);
     }
 
     &:disabled {
-      background-color: get-color('concrete');
-      color: get-color('gray');
+      background-color: get-color(sky, light);
+      color: get-color(sky);
       pointer-events: none;
     }
 
     &:active,
     &:hover {
       outline: none;
-      border: 1px solid get-color('dark-hot-pink');
+      border: 1px solid get-color(pink);
     }
 
     &--error {
-      border-color: get-color('crimson');
+      border-color: get-color(pink, dark);
 
       &:focus,
       &:active {
-        border: 1px solid get-color('crimson');
+        border: 1px solid get-color(pink, dark);
       }
     }
 
@@ -71,7 +71,7 @@
 
   &__error-message {
     margin-top: rem(4px);
-    color: get-color('crimson');
+    color: get-color(pink, dark);
     font-size: rem(14px);
   }
 }

--- a/src/components/MaSelect/MaSelect.scss
+++ b/src/components/MaSelect/MaSelect.scss
@@ -32,7 +32,7 @@
     }
 
     &:disabled {
-      background-color: get-color(gray, light);
+      background-color: get-color(gray, lighter);
       color: get-color(gray);
       pointer-events: none;
     }

--- a/src/components/MaSidebar/MaSidebar.scss
+++ b/src/components/MaSidebar/MaSidebar.scss
@@ -5,7 +5,7 @@
   flex-direction: column;
   z-index: 9999;
   margin: 0;
-  background-color: get-color('white');
+  background-color: get-color(white);
   min-width: rem(216px);
   overflow-x: hidden;
 

--- a/src/components/MaText/MaText.scss
+++ b/src/components/MaText/MaText.scss
@@ -36,7 +36,7 @@
     }
 
     &:disabled {
-      background-color: get-color(gray, light);
+      background-color: get-color(gray, lighter);
       color: get-color(gray);
       pointer-events: none;
     }

--- a/src/components/MaText/MaText.scss
+++ b/src/components/MaText/MaText.scss
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   width: 100%;
-  color: get-color('tundora');
+  color: get-color(ink, light);
 
   &__label-wrapper {
     display: flex;
@@ -22,34 +22,34 @@
   &__field {
     flex: 0 1 100%;
     transition: border 0.2s ease;
-    border: 1px solid get-color('alto');
-    background-color: get-color('white');
+    border: 1px solid get-color(sky, light);
+    background-color: get-color(white);
     padding: 0 rem(8px);
     max-width: 100%;
     height: 100%;
     font-size: rem(16px);
 
     &:focus {
-      outline: 2px solid get-color('classic-rose');
+      outline: 2px solid get-color(pink, light);
       outline-offset: 0;
-      border: 1px solid get-color('dark-hot-pink');
+      border: 1px solid get-color(pink);
     }
 
     &:disabled {
-      background-color: get-color('concrete');
-      color: get-color('gray');
+      background-color: get-color(sky, light);
+      color: get-color(sky);
       pointer-events: none;
     }
 
     &:active:not(:disabled),
     &:hover:not(:disabled) {
       outline: none;
-      border: 1px solid get-color('dark-hot-pink');
+      border: 1px solid get-color(pink);
     }
 
     &--error {
-      border-color: get-color('crimson');
-      background-color: get-color('white');
+      border-color: get-color(pink, dark);
+      background-color: get-color(white);
       background-image: url('../../assets/icons/alert-error.svg');
       background-position: calc(100% - 8px) center;
       background-repeat: no-repeat;
@@ -58,14 +58,14 @@
 
       &:focus,
       &:active {
-        border: 1px solid get-color('crimson');
+        border: 1px solid get-color(pink, dark);
       }
     }
   }
 
   &__error-message {
     margin-top: rem(4px);
-    color: get-color('crimson');
+    color: get-color(pink, dark);
     font-size: rem(14px);
   }
 }

--- a/src/components/MaText/MaText.scss
+++ b/src/components/MaText/MaText.scss
@@ -36,7 +36,7 @@
     }
 
     &:disabled {
-      background-color: get-color(gray, lighter);
+      background-color: get-color(brown, light);
       color: get-color(gray);
       pointer-events: none;
     }

--- a/src/components/MaText/MaText.scss
+++ b/src/components/MaText/MaText.scss
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   width: 100%;
-  color: get-color(ink, light);
+  color: get-color(gray, dark);
 
   &__label-wrapper {
     display: flex;
@@ -22,7 +22,7 @@
   &__field {
     flex: 0 1 100%;
     transition: border 0.2s ease;
-    border: 1px solid get-color(sky, light);
+    border: 1px solid get-color(gray, light);
     background-color: get-color(white);
     padding: 0 rem(8px);
     max-width: 100%;
@@ -36,8 +36,8 @@
     }
 
     &:disabled {
-      background-color: get-color(sky, light);
-      color: get-color(sky);
+      background-color: get-color(gray, light);
+      color: get-color(gray);
       pointer-events: none;
     }
 

--- a/src/components/colors.stories.js
+++ b/src/components/colors.stories.js
@@ -31,8 +31,8 @@ storiesOf('Colors', module).add('colors', () => ({
         alignItems: 'center',
       },
       colorStyle: {
-        width: '20px',
-        height: '20px',
+        width: '4vw',
+        height: '4vw',
         borderRadius: '2px',
       },
       textStyle: {

--- a/src/scss/_margarita-tokens.scss
+++ b/src/scss/_margarita-tokens.scss
@@ -1,14 +1,14 @@
 @import '~sass-mq';
 
+@import 'functions/colors';
+@import 'functions/rem';
+
 @import 'variables/colors';
 @import 'variables/fonts';
 @import 'variables/grid';
 
 @import 'animations/slide-animation';
 @import 'animations/horizontal-slide-animation';
-
-@import 'functions/colors';
-@import 'functions/rem';
 
 @import 'mixins/breakpoints';
 @import 'mixins/grid';

--- a/src/scss/functions/_colors.scss
+++ b/src/scss/functions/_colors.scss
@@ -1,13 +1,23 @@
-@function get-color($color: '') {
-  @return map-get($colors, $color);
-}
+/// Returns the color value for a given color name.
+///
+/// @param {String} $hue - The color's hue.
+/// @param {String} $value - The darkness/lightness of the color. Defaults to "base".
+/// @return {Color} The color value.
 
-@function get-darken-color($color: '', $amount: 0) {
-  @return darken(get-color($color), $amount);
-}
+@function get-color($hue, $value: base) {
+  $colorMap: map-get($colors, $hue);
 
-@function get-lighten-color($color: '', $amount: 0) {
-  @return lighten(get-color($color), $amount);
+  @if type-of($colorMap) != 'map' {
+    @error '`#{$hue} does not exist. Available colors: #{available-names($colors)}';
+  }
+
+  $fetched-color: map-get($colorMap, $value);
+
+  @if type-of($fetched-color) == color {
+    @return $fetched-color;
+  } @else {
+    @error 'Color `#{$hue} - #{$value}` not found. Available colors: #{available-names($colors)}';
+  }
 }
 
 @function get-alpha-color($color: '', $amount: 0) {

--- a/src/scss/mixins/_gradient-image.scss
+++ b/src/scss/mixins/_gradient-image.scss
@@ -1,9 +1,9 @@
 @mixin gradient-image($url) {
   background-image: linear-gradient(
       to bottom,
-      get-alpha-color('white', 1) 0%,
-      get-alpha-color('white', 0.8) 60%,
-      get-alpha-color('white', 0) 90%
+      get-alpha-color(white, 1) 0%,
+      get-alpha-color(white, 0.8) 60%,
+      get-alpha-color(white, 0) 90%
     ),
     url($url);
 
@@ -11,9 +11,9 @@
   &:focus {
     background-image: linear-gradient(
         to bottom,
-        get-alpha-color('white', 1) 0%,
-        get-alpha-color('white', 0.7) 60%,
-        get-alpha-color('white', 0) 90%
+        get-alpha-color(white, 1) 0%,
+        get-alpha-color(white, 0.7) 60%,
+        get-alpha-color(white, 0) 90%
       ),
       url($url);
     text-decoration: none;

--- a/src/scss/variables/_colors.scss
+++ b/src/scss/variables/_colors.scss
@@ -11,11 +11,11 @@ $colors: (
     base: #000000,
   ),
   gray: (
-    lightest: #f9f8f3,
+    lighter: #f9f8f3,
     light: #dcdcdc,
     base: #767676,
     dark: #4a4a4a,
-    darkest: #212121,
+    darker: #212121,
   ),
   green: (
     light: #e2f3ad,

--- a/src/scss/variables/_colors.scss
+++ b/src/scss/variables/_colors.scss
@@ -46,6 +46,7 @@ $colors: (
 // Temporary. How do we handle shadows?
 $shadow-light: rgba(0, 0, 0, 0.027451);
 $shadow-medium: rgba(0, 0, 0, 0.0980392);
+$shadow-dark: rgba(0, 0, 0, 0.498);
 
 :export {
   @each $name, $colorGroups in $colors {

--- a/src/scss/variables/_colors.scss
+++ b/src/scss/variables/_colors.scss
@@ -20,10 +20,14 @@ $colors: (
   green: (
     light: #e2f3ad,
     base: #237b01,
+    dark: #1f6d4a,
   ),
   blue: (
     light: #daf4fa,
     base: #296c89,
+  ),
+  turquoise: (
+    base: #24b578,
   ),
   yellow: (
     light: #fdf6dd,

--- a/src/scss/variables/_colors.scss
+++ b/src/scss/variables/_colors.scss
@@ -11,7 +11,6 @@ $colors: (
     base: #000000,
   ),
   gray: (
-    lighter: #f9f8f3,
     light: #dcdcdc,
     base: #767676,
     dark: #4a4a4a,
@@ -40,6 +39,10 @@ $colors: (
   ),
   orange: (
     base: #f06c17,
+  ),
+  brown: (
+    light: #f9f8f3,
+    base: #c8c0ab,
   ),
 );
 

--- a/src/scss/variables/_colors.scss
+++ b/src/scss/variables/_colors.scss
@@ -10,13 +10,12 @@ $colors: (
   black: (
     base: #000000,
   ),
-  sky: (
+  gray: (
+    lightest: #f9f8f3,
     light: #dcdcdc,
     base: #767676,
-  ),
-  ink: (
-    light: #4a4a4a,
-    base: #212121,
+    dark: #4a4a4a,
+    darkest: #212121,
   ),
   green: (
     light: #e2f3ad,

--- a/src/scss/variables/_colors.scss
+++ b/src/scss/variables/_colors.scss
@@ -40,15 +40,6 @@ $colors: (
   ),
 );
 
-@mixin gradient {
-  background-image: linear-gradient(
-    to right,
-    get-color(pink) 0%,
-    get-color(orange) 85%,
-    get-color(yellow, dark) 100%
-  );
-}
-
 // Temporary. How do we handle shadows?
 $shadow-light: rgba(0, 0, 0, 0.027451);
 $shadow-medium: rgba(0, 0, 0, 0.0980392);

--- a/src/scss/variables/_colors.scss
+++ b/src/scss/variables/_colors.scss
@@ -12,7 +12,7 @@ $colors: (
   ),
   sky: (
     light: #dcdcdc,
-    base: #878787,
+    base: #767676,
   ),
   ink: (
     light: #4a4a4a,

--- a/src/scss/variables/_colors.scss
+++ b/src/scss/variables/_colors.scss
@@ -1,47 +1,62 @@
 $colors: (
-  'alto': #dcdcdc,
-  'black': #000000,
-  'boulder': #767676,
-  'brown': #945d00,
-  'buttercup': #f5a623,
-  'calypso': #296c89,
-  'classic-rose': #facae5,
-  'concrete': #f3f3f3,
-  'crimson': #cb1010,
-  'dark-hot-pink': #e6007d,
-  'emperor': #505050,
-  'eucaliptus': #21865b,
-  'gray': #878787,
-  'humming-bird': #daf4fa,
-  'japanese-laurel': #237b01,
-  'lima': #70ba20,
-  'mine-shaft': #3b3b3b,
-  'peach-cream': #fff2dc,
-  'picton-blue': #54adec,
-  'pippin': #ffdddc,
-  'primrose': #e2f3ad,
-  'rice-flower': #edffda,
-  'school-bus-yellow': #ffdc00,
-  'scorpion': #595959,
-  'scotch-mist': #fff9dd,
-  'selective-yellow': #ffba03,
-  'shadow-dark': #0000007f,
-  'shadow-light': #00000007,
-  'shadow-medium': #00000019,
-  'solitude': #e7f6ff,
-  'sun': #f9a81d,
-  'tango': #f06c17,
-  'thunderbird': #cb1010,
-  'tundora': #4a4a4a,
-  'white': #ffffff,
-  'wild-sand': #f6f6f6,
+  pink: (
+    light: #f8b0cb,
+    base: #e6007d,
+    dark: #b3005d,
+  ),
+  white: (
+    base: #ffffff,
+  ),
+  black: (
+    base: #000000,
+  ),
+  sky: (
+    light: #dcdcdc,
+    base: #878787,
+  ),
+  ink: (
+    light: #4a4a4a,
+    base: #212121,
+  ),
+  green: (
+    light: #e2f3ad,
+    base: #237b01,
+  ),
+  blue: (
+    light: #daf4fa,
+    base: #296c89,
+  ),
+  yellow: (
+    light: #fdf6dd,
+    base: #f5d154,
+    dark: #ffba03,
+  ),
+  red: (
+    light: #ffdddc,
+    base: #cb1010,
+  ),
+  orange: (
+    base: #f06c17,
+  ),
 );
 
-$color-primary: get-color('dark-hot-pink');
+@mixin gradient {
+  background-image: linear-gradient(
+    to right,
+    get-color(pink) 0%,
+    get-color(orange) 85%,
+    get-color(yellow, dark) 100%
+  );
+}
 
-// export in order to use this variables from a JS file
+// Temporary. How do we handle shadows?
+$shadow-light: rgba(0, 0, 0, 0.027451);
+$shadow-medium: rgba(0, 0, 0, 0.0980392);
+
 :export {
-  @each $name, $color in $colors {
-    #{$name}: $color;
+  @each $name, $colorGroups in $colors {
+    @each $tone, $value in $colorGroups {
+      #{$name}-#{$tone}: $value;
+    }
   }
 }


### PR DESCRIPTION
Closes #254. This is obviously a huge breaking change 😄 

---

The proposal here is to use color maps to rely on way less variable names. This will make color usage way more simple (no more "Is this primrose? tundora? pippin" but rather "this is pink dark").

To do so, we leverage Sass' maps (a.k.a. arrays 🤷) to handle hues and variations.

New colors map: https://github.com/holaluz/margarita/blob/colors/src/scss/variables/_colors.scss

New  get-color function: https://github.com/holaluz/margarita/blob/colors/src/scss/functions/_colors.scss#L7

Result:


![image](https://user-images.githubusercontent.com/9197791/92619066-56f92580-f2c1-11ea-90e1-f5c77f99986a.png)




(_disclaimer: color ordering in this storybook screenshot is soooo poor, but I didn't want to spend much time there. Since colors are properly organized in Figma, we can easily check them out there_).

---

Out of Scope:

- gradients
- shadows
- fixing icons with Hex colors
- improving storybook's page on colors

---

- [x] Implement colors from Figma (currently missing "100% verde" colors)
- [x] Add new #F9F8F3 gray.
- [x] (_related to above_) Should we merge ink/sky colors into some "gray" map?
- [x] Agree on color naming. I kinda made up all names xD
- [x] Make sure old-new color equivalences are OK

The current equivalence of old-new colors is:

| old              | new          |
|------------------|--------------|
| dark-hot-pink    | pink         |
| classic-rose     | pink light   |
| pippin           | red light    |
| crimson          | red          |
| humming-bird     | blue light   |
| solitude     | blue light   |
| calypso          | blue         |
| picton-blue      | blue         |
| primrose         | green light  |
| japanese-laurel  | green        |
| peach-cream      | yellow light |
| brown            | yellow       |
| school-bus-yellow | yellow dark  |
| selective-yellow | yellow dark  |
| tango            | orange       |
| buttercup        | orange       |
| mine-shaft          | gray darker    |
| tundora          | gray dark    |
| emperor          | gray dark    |
| boulder          | gray          |
| scorpion         | gray          |
| gray         | gray          |
| alto             | gray light    |
| concrete         | brown light    |
| wild-sand        | brown ligth        |
