### PR TITLE
Fix: fix color CSS output

### DIFF
--- a/.storybook/colors.scss
+++ b/.storybook/colors.scss
@@ -1,0 +1,7 @@
+:export {
+  @each $name, $colorGroups in $colors {
+    @each $tone, $value in $colorGroups {
+      #{$name}-#{$tone}: $value;
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3169,6 +3169,12 @@
             "unique-filename": "^1.1.1"
           }
         },
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        },
         "chalk": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
@@ -3205,6 +3211,49 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
           "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
           "dev": true
+        },
+        "css-loader": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.6.0.tgz",
+          "integrity": "sha512-M5lSukoWi1If8dhQAUCvj4H8vUt3vOnwbQBH9DdTm/s4Ym2B/3dPMtYZeJmq7Q3S3Pa+I94DcZ7pc9bP14cWIQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.3.1",
+            "cssesc": "^3.0.0",
+            "icss-utils": "^4.1.1",
+            "loader-utils": "^1.2.3",
+            "normalize-path": "^3.0.0",
+            "postcss": "^7.0.32",
+            "postcss-modules-extract-imports": "^2.0.0",
+            "postcss-modules-local-by-default": "^3.0.2",
+            "postcss-modules-scope": "^2.2.0",
+            "postcss-modules-values": "^3.0.0",
+            "postcss-value-parser": "^4.1.0",
+            "schema-utils": "^2.7.0",
+            "semver": "^6.3.0"
+          },
+          "dependencies": {
+            "json5": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+              "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+              "dev": true,
+              "requires": {
+                "minimist": "^1.2.0"
+              }
+            },
+            "loader-utils": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+              "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+              "dev": true,
+              "requires": {
+                "big.js": "^5.2.2",
+                "emojis-list": "^3.0.0",
+                "json5": "^1.0.1"
+              }
+            }
+          }
         },
         "ejs": {
           "version": "3.1.5",
@@ -5104,6 +5153,12 @@
             "color-convert": "^2.0.1"
           }
         },
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        },
         "cliui": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
@@ -5162,6 +5217,40 @@
                 "ignore": "^3.3.5",
                 "pify": "^3.0.0",
                 "slash": "^1.0.0"
+              }
+            }
+          }
+        },
+        "css-loader": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.6.0.tgz",
+          "integrity": "sha512-M5lSukoWi1If8dhQAUCvj4H8vUt3vOnwbQBH9DdTm/s4Ym2B/3dPMtYZeJmq7Q3S3Pa+I94DcZ7pc9bP14cWIQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.3.1",
+            "cssesc": "^3.0.0",
+            "icss-utils": "^4.1.1",
+            "loader-utils": "^1.2.3",
+            "normalize-path": "^3.0.0",
+            "postcss": "^7.0.32",
+            "postcss-modules-extract-imports": "^2.0.0",
+            "postcss-modules-local-by-default": "^3.0.2",
+            "postcss-modules-scope": "^2.2.0",
+            "postcss-modules-values": "^3.0.0",
+            "postcss-value-parser": "^4.1.0",
+            "schema-utils": "^2.7.0",
+            "semver": "^6.3.0"
+          },
+          "dependencies": {
+            "schema-utils": {
+              "version": "2.7.1",
+              "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
+              "integrity": "sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==",
+              "dev": true,
+              "requires": {
+                "@types/json-schema": "^7.0.5",
+                "ajv": "^6.12.4",
+                "ajv-keywords": "^3.5.2"
               }
             }
           }
@@ -9904,41 +9993,6 @@
       "requires": {
         "postcss": "^7.0.1",
         "timsort": "^0.3.0"
-      }
-    },
-    "css-loader": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.6.0.tgz",
-      "integrity": "sha512-M5lSukoWi1If8dhQAUCvj4H8vUt3vOnwbQBH9DdTm/s4Ym2B/3dPMtYZeJmq7Q3S3Pa+I94DcZ7pc9bP14cWIQ==",
-      "dev": true,
-      "requires": {
-        "camelcase": "^5.3.1",
-        "cssesc": "^3.0.0",
-        "icss-utils": "^4.1.1",
-        "loader-utils": "^1.2.3",
-        "normalize-path": "^3.0.0",
-        "postcss": "^7.0.32",
-        "postcss-modules-extract-imports": "^2.0.0",
-        "postcss-modules-local-by-default": "^3.0.2",
-        "postcss-modules-scope": "^2.2.0",
-        "postcss-modules-values": "^3.0.0",
-        "postcss-value-parser": "^4.1.0",
-        "schema-utils": "^2.7.0",
-        "semver": "^6.3.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-          "dev": true
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        }
       }
     },
     "css-select": {
@@ -18141,6 +18195,12 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+      "dev": true
+    },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
     "lodash.shuffle": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "jest-watch-typeahead": "^0.6.1",
     "lint-staged": "^10.4.0",
     "lodash.camelcase": "^4.3.0",
+    "lodash.merge": "^4.6.2",
     "lodash.shuffle": "^4.2.0",
     "markdown-loader": "^5.1.0",
     "node-sass": "^4.14.1",

--- a/src/components/colors.stories.js
+++ b/src/components/colors.stories.js
@@ -25,12 +25,14 @@ export const Colors = () => ({
         <h2 :style="titleStyle">{{hue}}</h2>
         <div v-for="(hex, tone) in tones" :key="tone" :style="colorStyle">
           <div :style="getBoxStyle(hex)">
-            <p :style="colorNameStyle">{{hue}} {{tone}}</p>
-            <code v-text="hex" />
             <code v-text="getFunction(hue, tone)" />
           </div>
+          <p :style="colorNameStyle">
+            {{hue}} {{tone}}
+            <code v-text="hex" :style="hexStyle" />
+          </p>
         </div>
-        </div>
+      </div>
     </div>
   `,
 
@@ -40,38 +42,38 @@ export const Colors = () => ({
       titleStyle: {
         textAlign: 'center',
         textTransform: 'capitalize',
-        marginTop: '1.5rem',
-        fontSize: '1.5rem',
+        fontSize: '1.4rem',
         fontWeight: 'normal',
       },
       containerStyle: {
         display: 'grid',
-        gridGap: '1.5em',
-        gridTemplateColumns: 'repeat(3, minmax(100px,1fr))',
-        maxWidth: '800px',
+        gridGap: '4vw',
+        gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
+        maxWidth: '1400px',
         margin: '0 auto',
       },
       colorStyle: {
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
         marginTop: '0.5rem',
-        textTransform: 'capitalize',
       },
       colorNameStyle: {
-        margin: '0 0 1rem 0',
-        fontSize: '1.2rem',
+        display: 'flex',
+        justifyContent: 'space-around',
+        alignItems: 'center',
+        margin: '1rem 0 2rem 0',
+        fontWeight: 'bold',
+      },
+      hexStyle: {
+        fontWeight: 'normal',
+        fontSize: '0.8rem',
       },
       boxStyle: {
         display: 'flex',
-        flexDirection: 'column',
         alignItems: 'center',
         justifyContent: 'center',
-        gap: '0.5rem',
-        width: '100%',
         height: '140px',
-        borderRadius: '2px',
+        borderRadius: '4px',
         boxShadow: '3px 2px 12px rgba(0,0,0,0.15)',
+        fontSize: '0.8rem',
       },
     }
   },
@@ -91,19 +93,15 @@ export const Colors = () => ({
         : `get-color(${hue}, ${tone})`
     },
 
-    getContrast(input) {
-      const color = input.startsWith('#') ? input.slice(1) : input
+    getContrast(color) {
+      const r = parseInt(color.substr(1, 2), 16)
+      const g = parseInt(color.substr(3, 2), 16)
+      const b = parseInt(color.substr(5, 2), 16)
 
-      // Convert to RGB value
-      const r = parseInt(color.substr(0, 2), 16)
-      const g = parseInt(color.substr(2, 2), 16)
-      const b = parseInt(color.substr(4, 2), 16)
+      // https://en.wikipedia.org/wiki/YIQ#From_RGB_to_YIQ
+      const yiqRatio = (r * 299 + g * 587 + b * 114) / 1000
 
-      // Get YIQ ratio
-      const yiq = (r * 299 + g * 587 + b * 114) / 1000
-
-      // Check contrast
-      return yiq >= 128 ? 'black' : 'white'
+      return yiqRatio >= 128 ? 'black' : 'white'
     },
   },
 })

--- a/src/components/colors.stories.js
+++ b/src/components/colors.stories.js
@@ -1,4 +1,18 @@
-import colors from '../scss/_margarita.scss'
+import merge from 'lodash.merge'
+import '../scss/_margarita.scss'
+import rawColors from '../../.storybook/colors.scss'
+
+const colors = Object.entries(rawColors).reduce(
+  (acc, [composedColorName, hex]) => {
+    const [hue, tone] = composedColorName.split('-')
+    return merge(acc, {
+      [hue]: {
+        [tone]: hex,
+      },
+    })
+  },
+  {}
+)
 
 export default {
   title: 'Tokens/Colors',
@@ -7,50 +21,89 @@ export default {
 export const Colors = () => ({
   template: `
     <div :style="containerStyle">
-      <div
-        v-for="(color, colorName) in colors"
-        :key="color"
-        :style="colorContainerStyle"
-      >
-        <div :style="getColorStyle(color)"></div>
-        <div :style="textStyle">
-          <b>{{ colorName }}</b><br>
-          <small>({{ color }})</small>
+      <div v-for="(tones, hue) in colors" :key="hue">
+        <h2 :style="titleStyle">{{hue}}</h2>
+        <div v-for="(hex, tone) in tones" :key="tone" :style="colorStyle">
+          <div :style="getBoxStyle(hex)">
+            <p :style="colorNameStyle">{{hue}} {{tone}}</p>
+            <code v-text="hex" />
+            <code v-text="getFunction(hue, tone)" />
+          </div>
         </div>
-      </div>
+        </div>
     </div>
   `,
 
   data() {
     return {
       colors,
+      titleStyle: {
+        textAlign: 'center',
+        textTransform: 'capitalize',
+        marginTop: '1.5rem',
+        fontSize: '1.5rem',
+        fontWeight: 'normal',
+      },
       containerStyle: {
         display: 'grid',
         gridGap: '1.5em',
-        gridTemplateColumns: 'repeat(4, 1fr)',
-      },
-      colorContainerStyle: {
-        display: 'flex',
-        alignItems: 'center',
+        gridTemplateColumns: 'repeat(3, minmax(100px,1fr))',
+        maxWidth: '800px',
+        margin: '0 auto',
       },
       colorStyle: {
-        width: '4vw',
-        height: '4vw',
-        borderRadius: '2px',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        marginTop: '0.5rem',
+        textTransform: 'capitalize',
       },
-      textStyle: {
-        opacity: 0.8,
-        paddingLeft: '.5em',
+      colorNameStyle: {
+        margin: '0 0 1rem 0',
+        fontSize: '1.2rem',
+      },
+      boxStyle: {
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: '0.5rem',
+        width: '100%',
+        height: '140px',
+        borderRadius: '2px',
+        boxShadow: '3px 2px 12px rgba(0,0,0,0.15)',
       },
     }
   },
 
   methods: {
-    getColorStyle(backgroundColor) {
+    getBoxStyle(color) {
       return {
-        ...this.colorStyle,
-        backgroundColor,
+        ...this.boxStyle,
+        backgroundColor: color,
+        color: this.getContrast(color),
       }
+    },
+
+    getFunction(hue, tone) {
+      return tone === 'base'
+        ? `get-color(${hue})`
+        : `get-color(${hue}, ${tone})`
+    },
+
+    getContrast(input) {
+      const color = input.startsWith('#') ? input.slice(1) : input
+
+      // Convert to RGB value
+      const r = parseInt(color.substr(0, 2), 16)
+      const g = parseInt(color.substr(2, 2), 16)
+      const b = parseInt(color.substr(4, 2), 16)
+
+      // Get YIQ ratio
+      const yiq = (r * 299 + g * 587 + b * 114) / 1000
+
+      // Check contrast
+      return yiq >= 128 ? 'black' : 'white'
     },
   },
 })

--- a/src/scss/variables/_colors.scss
+++ b/src/scss/variables/_colors.scss
@@ -32,17 +32,17 @@ $colors: (
   turquoise: (
     base: #24b578,
   ),
-  white: (
-    base: #ffffff,
-  ),
-  black: (
-    base: #000000,
-  ),
   gray: (
     light: #dcdcdc,
     base: #767676,
     dark: #4a4a4a,
     darker: #212121,
+  ),
+  black: (
+    base: #000000,
+  ),
+  white: (
+    base: #ffffff,
   ),
 );
 

--- a/src/scss/variables/_colors.scss
+++ b/src/scss/variables/_colors.scss
@@ -50,11 +50,3 @@ $colors: (
 $shadow-light: rgba(0, 0, 0, 0.027451);
 $shadow-medium: rgba(0, 0, 0, 0.0980392);
 $shadow-dark: rgba(0, 0, 0, 0.498);
-
-:export {
-  @each $name, $colorGroups in $colors {
-    @each $tone, $value in $colorGroups {
-      #{$name}-#{$tone}: $value;
-    }
-  }
-}

--- a/src/scss/variables/_colors.scss
+++ b/src/scss/variables/_colors.scss
@@ -4,6 +4,34 @@ $colors: (
     base: #e6007d,
     dark: #b3005d,
   ),
+  green: (
+    light: #e2f3ad,
+    base: #237b01,
+    dark: #1f6d4a,
+  ),
+  yellow: (
+    light: #fdf6dd,
+    base: #f5d154,
+    dark: #ffba03,
+  ),
+  blue: (
+    light: #daf4fa,
+    base: #296c89,
+  ),
+  red: (
+    light: #ffdddc,
+    base: #cb1010,
+  ),
+  brown: (
+    light: #f9f8f3,
+    base: #c8c0ab,
+  ),
+  orange: (
+    base: #f06c17,
+  ),
+  turquoise: (
+    base: #24b578,
+  ),
   white: (
     base: #ffffff,
   ),
@@ -15,34 +43,6 @@ $colors: (
     base: #767676,
     dark: #4a4a4a,
     darker: #212121,
-  ),
-  green: (
-    light: #e2f3ad,
-    base: #237b01,
-    dark: #1f6d4a,
-  ),
-  blue: (
-    light: #daf4fa,
-    base: #296c89,
-  ),
-  turquoise: (
-    base: #24b578,
-  ),
-  yellow: (
-    light: #fdf6dd,
-    base: #f5d154,
-    dark: #ffba03,
-  ),
-  red: (
-    light: #ffdddc,
-    base: #cb1010,
-  ),
-  orange: (
-    base: #f06c17,
-  ),
-  brown: (
-    light: #f9f8f3,
-    base: #c8c0ab,
   ),
 );
 


### PR DESCRIPTION
This PR fixes an issue with the generated CSS (see the following [thread in slack](https://holaluz.slack.com/archives/C019DLZTBU6/p1600701743003300?thread_ts=1600675842.001100&cid=C019DLZTBU6)).

tl;dr: some sass loader was transforming `white-base` to `#fff-base`, thus breaking the `:export` statement. Since that statement was only meant to provide colors to the storybook story, I removed it from the CSS output and put it back inside storybook.

Also I took the liberty to improve the colors page _a bit_:

<img width="1137" alt="image" src="https://user-images.githubusercontent.com/9197791/93993552-2b7d3d00-fd8f-11ea-96f3-0ae36ea09bca.png">
