### PR TITLE
fix(perf): Remove support for dead browsers 

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,3 +1,3 @@
 > 1%
 last 2 versions
-not ie <= 8
+not dead


### PR DESCRIPTION
From this:

![Captura de Pantalla 2020-12-19 a les 21 11 11](https://user-images.githubusercontent.com/9197791/102698612-076eb200-423f-11eb-8166-052f989b824c.png)


to this:

![Captura de Pantalla 2020-12-19 a les 21 11 32](https://user-images.githubusercontent.com/9197791/102698615-09387580-423f-11eb-9e28-de6ebaca3a44.png)

🎉 

10 KiB of CSS removed by excluding the following browers:

```
bb 10 (Blackberry Browser)
bb 7
ie 10 (Internet Explorer – obviously)
ie_mob 11 Internet Explorer Mobile (I didn't even know this was a thing)
ie_mob 10 (Opera Mobile)
op_mob 12.1
```

all browsers above are listed as dead ("dead" as in "_browsers without official support or updates for 24 months_"), so we should not be supporting them – even IE 10, which I believe we're already not supporting given the features we're currently using.


I suggest we created a shared browserslist config. Sadly enough Browserslist do not support `.js` config files so we can't simply add it on `npm-scripts`. Their docs suggest [creating a npm package](https://github.com/browserslist/browserslist#shareable-configs), but I'd like to stuff it into npm-scripts very much. Any ideas?


---

Notice that this PR along with #307 reduces our bundled CSS from ~60KiB to 38 by changing 2 lines of code. 💥 
