### PR TITLE
chore: Fix jsconfig warnings

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,13 +1,11 @@
 {
-  "allowJs": true,
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"],
-      "@margarita/*": ["./src/*"],
-      "@@/*": ["./*"]
+      "@/*": ["src/*"],
+      "@margarita/*": ["src/*"],
+      "@@/*": ["/*"]
     }
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "storybook-static"]
 }

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -7,9 +7,3 @@ declare module 'vue/types/vue' {
     $layout: Layout
   }
 }
-
-declare module 'vue/types/options' {
-  interface ComponentOptions<V extends Vue> {
-    layout: Layout
-  }
-}


### PR DESCRIPTION
Looks like some path weren't properly set due to include/exclude, and VSC was complaining about unreachable paths. I followed [docs](https://code.visualstudio.com/docs/languages/jsconfig) and now it looks good.

I also removed the unused Vue.options types, as we're not really using them.