### PR TITLE
feat: Autogenerate component & prop autocompletion for Margarita components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,8 @@ npm-debug.log*
 # vscode
 .vscode/!settings.json
 
+# auto generated vetur files
+vetur
+
 # auto generated scss token file
 src/scss/_tokens.scss

--- a/package-lock.json
+++ b/package-lock.json
@@ -4407,6 +4407,18 @@
         }
       }
     },
+    "@vue-intellisense/scripts": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@vue-intellisense/scripts/-/scripts-0.1.2.tgz",
+      "integrity": "sha512-rehSMDoMxJac9NYNThkI/mJYMki5hf66WljfL3yU6BPTOamKMCJNld9Dk4pt4wpLWuAsTJkAKq4yb7sF+1Q3uA==",
+      "dev": true,
+      "requires": {
+        "case-anything": "^1.1.2",
+        "is-what": "^3.12.0",
+        "merge-anything": "^4.0.0",
+        "vue-docgen-api": "^4.34.2"
+      }
+    },
     "@vue/babel-helper-vue-jsx-merge-props": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@vue/babel-helper-vue-jsx-merge-props/-/babel-helper-vue-jsx-merge-props-1.2.1.tgz",
@@ -7614,6 +7626,40 @@
         "file-uri-to-path": "1.0.0"
       }
     },
+    "bl": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
+      "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -8289,6 +8335,12 @@
         "ansicolors": "~0.3.2",
         "redeyed": "~2.1.0"
       }
+    },
+    "case-anything": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-1.1.2.tgz",
+      "integrity": "sha512-rPRbQJ5amW9wKZTlRHErLBZwWr4mWO6WhTkrlLp0XdI/i4JrhLv2wahg5jgmn5Rm2fOUjlmMz6DUH4mnUfWkow==",
+      "dev": true
     },
     "case-sensitive-paths-webpack-plugin": {
       "version": "2.3.0",
@@ -15325,6 +15377,12 @@
       "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
       "dev": true
     },
+    "is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true
+    },
     "is-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.1.tgz",
@@ -15532,6 +15590,12 @@
       "requires": {
         "is-non-null-object": "^1.0.0"
       }
+    },
+    "is-what": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-3.12.0.tgz",
+      "integrity": "sha512-2ilQz5/f/o9V7WRWJQmpFYNmQFZ9iM+OXRonZKcYgTkCzjb949Vi4h282PD1UfmgHk666rcWonbRJ++KI41VGw==",
+      "dev": true
     },
     "is-whitespace": {
       "version": "0.3.0",
@@ -20594,6 +20658,16 @@
             "get-stdin": "^4.0.1"
           }
         }
+      }
+    },
+    "merge-anything": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/merge-anything/-/merge-anything-4.0.0.tgz",
+      "integrity": "sha512-mTRT1Zna+vMJZasYCNSYmXGqr0mnIi/8pfiRWQ8QlH08qVBu51q1FwiUGabz7VkVhLSHIOWEPA7s0DM3ykLUQw==",
+      "dev": true,
+      "requires": {
+        "is-what": "^3.11.3",
+        "ts-toolbelt": "^8.0.7"
       }
     },
     "merge-descriptors": {
@@ -31528,6 +31602,12 @@
       "integrity": "sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==",
       "dev": true
     },
+    "ts-toolbelt": {
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-8.0.7.tgz",
+      "integrity": "sha512-KICHyKxc5Nu34kyoODrEe2+zvuQQaubTJz7pnC5RQ19TH/Jged1xv+h8LBrouaSD310m75oAljYs59LNHkLDkQ==",
+      "dev": true
+    },
     "tsconfig": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
@@ -32362,6 +32442,216 @@
       "dev": true,
       "requires": {
         "camelcase": "^5.3.1"
+      }
+    },
+    "vue-intellisense": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/vue-intellisense/-/vue-intellisense-0.1.2.tgz",
+      "integrity": "sha512-HzNAKOz+dnTF8XX7FIlt/PnPrFB6sz4aXnIREMNwflasx/6/TkYEFFNcUYjHQNY9q8W8Rebs68nVq3ljPADYHA==",
+      "dev": true,
+      "requires": {
+        "@vue-intellisense/scripts": "^0.1.2",
+        "case-anything": "^1.1.2",
+        "chalk": "^4.1.0",
+        "is-what": "^3.12.0",
+        "log-symbols": "^4.0.0",
+        "meow": "^8.1.0",
+        "ora": "^5.2.0",
+        "vue-docgen-api": "^4.34.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "camelcase-keys": {
+          "version": "6.2.2",
+          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+          "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.3.1",
+            "map-obj": "^4.0.0",
+            "quick-lru": "^4.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "hosted-git-info": {
+          "version": "3.0.7",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.7.tgz",
+          "integrity": "sha512-fWqc0IcuXs+BmE9orLDyVykAG9GJtGLGuZAAqgcckPgv5xad4AcXGIv8galtQvlwutxSlaMcdw7BUtq2EIvqCQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "log-symbols": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
+          "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0"
+          }
+        },
+        "map-obj": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.1.0.tgz",
+          "integrity": "sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==",
+          "dev": true
+        },
+        "meow": {
+          "version": "8.1.2",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
+          "integrity": "sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==",
+          "dev": true,
+          "requires": {
+            "@types/minimist": "^1.2.0",
+            "camelcase-keys": "^6.2.2",
+            "decamelize-keys": "^1.1.0",
+            "hard-rejection": "^2.1.0",
+            "minimist-options": "4.1.0",
+            "normalize-package-data": "^3.0.0",
+            "read-pkg-up": "^7.0.1",
+            "redent": "^3.0.0",
+            "trim-newlines": "^3.0.0",
+            "type-fest": "^0.18.0",
+            "yargs-parser": "^20.2.3"
+          }
+        },
+        "normalize-package-data": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.0.tgz",
+          "integrity": "sha512-6lUjEI0d3v6kFrtgA/lOx4zHCWULXsFNIjHolnZCKCTLA6m/G625cdn3O7eNmT0iD3jfo6HZ9cdImGZwf21prw==",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^3.0.6",
+            "resolve": "^1.17.0",
+            "semver": "^7.3.2",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
+        "ora": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ora/-/ora-5.2.0.tgz",
+          "integrity": "sha512-+wG2v8TUU8EgzPHun1k/n45pXquQ9fHnbXVetl9rRgO6kjZszGGbraF3XPTIdgeA+s1lbRjSEftAnyT0w8ZMvQ==",
+          "dev": true,
+          "requires": {
+            "bl": "^4.0.3",
+            "chalk": "^4.1.0",
+            "cli-cursor": "^3.1.0",
+            "cli-spinners": "^2.5.0",
+            "is-interactive": "^1.0.0",
+            "log-symbols": "^4.0.0",
+            "strip-ansi": "^6.0.0",
+            "wcwidth": "^1.0.1"
+          }
+        },
+        "read-pkg-up": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+          "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+          "dev": true,
+          "requires": {
+            "find-up": "^4.1.0",
+            "read-pkg": "^5.2.0",
+            "type-fest": "^0.8.1"
+          },
+          "dependencies": {
+            "type-fest": {
+              "version": "0.8.1",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+              "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+              "dev": true
+            }
+          }
+        },
+        "semver": {
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "trim-newlines": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
+          "integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==",
+          "dev": true
+        },
+        "type-fest": {
+          "version": "0.18.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+          "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
+          "dev": true
+        },
+        "yargs-parser": {
+          "version": "20.2.4",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+          "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+          "dev": true
+        }
       }
     },
     "vue-jest": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   ],
   "scripts": {
     "prepare": "npm run tokens:build && npm run vetur:build",
-    "prebuild": "npm run tokens:build",
     "build": "vue-cli-service build --target lib --name margarita src/index.js",
     "format": "prettier 'src/**/*.{js,vue}' --write && stylelint 'src/**/*.scss' --fix",
     "lint": "npm run lint:js && npm run lint:css",

--- a/package.json
+++ b/package.json
@@ -12,23 +12,25 @@
   "files": [
     "dist",
     "src",
-    "types/*.d.ts"
+    "types/*.d.ts",
+    "vetur"
   ],
   "scripts": {
+    "prepare": "npm run tokens:build && npm run vetur:build",
     "prebuild": "npm run tokens:build",
     "build": "vue-cli-service build --target lib --name margarita src/index.js",
     "format": "prettier 'src/**/*.{js,vue}' --write && stylelint 'src/**/*.scss' --fix",
     "lint": "npm run lint:js && npm run lint:css",
     "lint:css": "stylelint 'src/**/*.scss'",
     "lint:js": "eslint 'src/**/*.{js,vue}'",
-    "prestart": "npm run tokens:build",
     "start": "npm run storybook:serve & npm run tokens:watch",
     "storybook:build": "vue-cli-service storybook:build -c .storybook",
     "storybook:serve": "vue-cli-service storybook:serve -p 6006 -c .storybook",
     "test": "vue-cli-service test:unit",
     "test:watch": "vue-cli-service test:unit --watch",
     "tokens:build": "style-dictionary build --platform scss --config ./style-dictionary.config.js && prettier 'src/scss/*' --write",
-    "tokens:watch": "chokidar  'src/tokens/*.js' -c 'npm run tokens:build'"
+    "tokens:watch": "chokidar  'src/tokens/*.js' -c 'npm run tokens:build'",
+    "vetur:build": "vue-int --output 'vetur' --input 'src/components' --recursive"
   },
   "husky": {
     "hooks": {
@@ -95,10 +97,15 @@
     "stylelint-config-prettier": "^8.0.2",
     "stylelint-prettier": "^1.1.0",
     "vue-cli-plugin-storybook": "^2.0.0",
+    "vue-intellisense": "^0.1.1",
     "vue-template-compiler": "^2.6.12"
   },
   "publishConfig": {
     "access": "public"
   },
-  "jsDelivr": "dist/margarita.umd.min.js"
+  "jsDelivr": "dist/margarita.umd.min.js",
+  "vetur": {
+    "tags": "vetur/tags.json",
+    "attributes": "vetur/attributes.json"
+  }
 }


### PR DESCRIPTION
This PR adds a first iteration of the component autocompletion & intellisense that Vetur can offer.

## What does the PR do

It yields the following result:

![Captura de Pantalla 2021-01-11 a les 11 42 16](https://user-images.githubusercontent.com/9197791/104173414-0415b300-5406-11eb-8c4c-f2113dd32e29.png)

![imatge](https://user-images.githubusercontent.com/9197791/104173674-6cfd2b00-5406-11eb-9f50-eb7247851452.png)


## What's missing

It doesn't add "values" or description for each prop. This needs to be done manually by adding JSDoc comments to each prop. [Here](https://github.com/CyCraft/vue-intellisense/blob/production/packages/scripts/test/helpers/BlitzForm.vue#L9) you have an example of available fields.

btw, these JSDoc comments will also be used by Storybook or any other platform to document components, so work done there will be used everywhere and will become the source of truth for props documentation. Quite neat.

