### PR TITLE
feat: Generate CSS custom properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ vetur
 
 # auto generated scss token file
 src/scss/_tokens.scss
+
+# auto generated css custom properties file
+src/css/tokens.css

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "prepare": "npm run tokens:build && npm run vetur:build",
     "build": "vue-cli-service build --target lib --name margarita src/index.js",
-    "format": "prettier 'src/**/*.{js,vue}' --write && stylelint 'src/**/*.scss' --fix",
+    "format": "prettier 'src/**/*.{js,vue,css}' --write && stylelint 'src/**/*.scss' --fix",
     "lint": "npm run lint:js && npm run lint:css",
     "lint:css": "stylelint 'src/**/*.scss'",
     "lint:js": "eslint 'src/**/*.{js,vue}'",
@@ -27,9 +27,9 @@
     "storybook:serve": "vue-cli-service storybook:serve -p 6006 -c .storybook",
     "test": "vue-cli-service test:unit",
     "test:watch": "vue-cli-service test:unit --watch",
-    "tokens:build": "style-dictionary build --platform scss --config ./style-dictionary.config.js && prettier 'src/scss/*' --write",
-    "tokens:watch": "chokidar  'src/tokens/*.js' -c 'npm run tokens:build'",
-    "vetur:build": "vue-int --output 'vetur' --input 'src/components' --recursive"
+    "vetur:build": "vue-int --output 'vetur' --input 'src/components' --recursive",
+    "tokens:build": "style-dictionary build --config ./style-dictionary.config.js && prettier 'src/scss/*' --write",
+    "tokens:watch": "chokidar  'src/tokens/*.js' -c 'npm run tokens:build'"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
     "storybook:serve": "vue-cli-service storybook:serve -p 6006 -c .storybook",
     "test": "vue-cli-service test:unit",
     "test:watch": "vue-cli-service test:unit --watch",
-    "vetur:build": "vue-int --output 'vetur' --input 'src/components' --recursive",
     "tokens:build": "style-dictionary build --config ./style-dictionary.config.js && prettier 'src/scss/*' --write",
-    "tokens:watch": "chokidar  'src/tokens/*.js' -c 'npm run tokens:build'"
+    "tokens:watch": "chokidar  'src/tokens/*.js' -c 'npm run tokens:build'",
+    "vetur:build": "vue-int --output 'vetur' --input 'src/components' --recursive"
   },
   "husky": {
     "hooks": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import './css/tokens.css'
 import './scss/_margarita.scss'
 
 import MaAlert from './components/MaAlert'

--- a/style-dictionary.config.js
+++ b/style-dictionary.config.js
@@ -1,6 +1,15 @@
 module.exports = {
   source: ['.style-dictionary/index.js'],
   platforms: {
+    css: {
+      transformGroup: 'css',
+      files: [
+        {
+          format: 'css/variables',
+          destination: './src/css/tokens.css',
+        },
+      ],
+    },
     scss: {
       transformGroup: 'scss',
       buildPath: './src/scss/',


### PR DESCRIPTION
This PR adds CSS custom property to the Margarita CSS output. This is yet another step in the direction of replacing SCSS (#298), and will help us avoid using it in new projects such as nuxt-clean.

---

For the record, this is the output CSS:

```css
:root {
  --color-pink-light: #f8b0cb;
  --color-pink-base: #e6007d;
  --color-pink-dark: #b3005d;
  --color-green-light: #e2f3ad;
  --color-green-base: #237b01;
  --color-green-dark: #1f6d4a;
  --color-yellow-light: #fdf6dd;
  --color-yellow-base: #f5d154;
  --color-yellow-dark: #ffba03;
  --color-blue-light: #daf4fa;
  --color-blue-base: #296c89;
  --color-red-light: #ffdddc;
  --color-red-base: #cb1010;
  --color-brown-light: #f9f8f3;
  --color-brown-base: #c8c0ab;
  --color-orange-base: #f06c17;
  --color-turquoise-base: #24b578;
  --color-gray-lighter: #f6f6f6;
  --color-gray-light: #dcdcdc;
  --color-gray-base: #767676;
  --color-gray-dark: #4a4a4a;
  --color-gray-darker: #212121;
  --color-black-base: #000000;
  --color-white-base: #ffffff;

  --spacing-none: 0;
  --spacing-xxsmall: 1rem;
  --spacing-xsmall: 1.5rem;
  --spacing-small: 2rem;
  --spacing-medium: 3rem;
  --spacing-large: 4rem;
  --spacing-xlarge: 5rem;
  --spacing-xxlarge: 6rem;
  --spacing-xxxlarge: 8rem;

  --shadow-light: rgba(0, 0, 0, 0.027451);
  --shadow-medium: rgba(0, 0, 0, 0.0980392);
  --shadow-dark: rgba(0, 0, 0, 0.498);

  --breakpoint-tablet: 900;
  --breakpoint-desktop: 1440;
}
```