### PR TITLE
fix: Remove rem function usage

### DIFF
--- a/src/components/MaAlert/MaAlert.scss
+++ b/src/components/MaAlert/MaAlert.scss
@@ -3,30 +3,30 @@
   color: get-color(gray, darker);
 
   &--small {
-    padding: rem(4px);
+    padding: 0.25rem;
 
     @include mq($from: sm) {
-      padding: rem(8px);
+      padding: 0.5rem;
     }
 
     .alert-banner__icon {
-      margin-right: rem(8px);
+      margin-right: 0.5rem;
     }
   }
 
   &--medium {
-    padding: rem(8px);
+    padding: 0.5rem;
 
     @include mq($from: sm) {
-      padding: rem(16px);
+      padding: 1rem;
     }
   }
 
   &--large {
-    padding: rem(12px);
+    padding: 0.75rem;
 
     @include mq($from: sm) {
-      padding: rem(24px);
+      padding: 1.5rem;
     }
   }
 
@@ -37,12 +37,12 @@
 
   &__icon {
     display: block;
-    margin-right: rem(16px);
+    margin-right: 1rem;
     background-repeat: no-repeat;
     background-size: 100% 100%;
-    width: rem(20px);
-    min-width: rem(20px);
-    height: rem(20px);
+    width: 1.25rem;
+    min-width: 1.25rem;
+    height: 1.25rem;
 
     .alert-banner--error & {
       background-image: url('../../assets/icons/alert-error.svg');
@@ -70,8 +70,8 @@
     @include font-weight(semibold);
 
     margin: 0;
-    margin-bottom: rem(8px);
-    font-size: rem(20px);
+    margin-bottom: 0.5rem;
+    font-size: 1.25rem;
   }
 
   &--error {

--- a/src/components/MaButton/MaButton.scss
+++ b/src/components/MaButton/MaButton.scss
@@ -6,10 +6,10 @@
   transition: background-color 0.3s, background-position 0.3s, border-color 0.3s;
   border: 1px solid transparent;
   cursor: pointer;
-  padding: rem(9px);
+  padding: 0.5rem;
   text-decoration: none;
   line-height: 1.13;
-  font-size: rem(16px);
+  font-size: 1rem;
 
   &:disabled {
     cursor: not-allowed;
@@ -28,7 +28,7 @@
   &--rounded {
     flex-grow: 0;
     border-radius: 100%;
-    padding: rem(11px);
+    padding: 0.75rem;
   }
 
   &--no-background {

--- a/src/components/MaCard/MaCard.scss
+++ b/src/components/MaCard/MaCard.scss
@@ -1,5 +1,5 @@
 .ma-card {
-  padding: rem(24px);
+  padding: 1.5rem;
 
   &--gray {
     background-color: get-color(brown, light);
@@ -11,6 +11,6 @@
   }
 
   &--has-padding-top {
-    padding-top: rem(24px);
+    padding-top: 1.5rem;
   }
 }

--- a/src/components/MaDatagrid/MaDatagrid.scss
+++ b/src/components/MaDatagrid/MaDatagrid.scss
@@ -33,10 +33,10 @@
     tr {
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-      margin-bottom: rem(16px);
+      margin-bottom: 1rem;
 
       th {
-        padding: 0 rem(16px);
+        padding: 0 1rem;
         text-align: left;
         user-select: none;
 
@@ -57,7 +57,7 @@
       grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
       align-items: center;
       margin-bottom: 1rem;
-      border-radius: rem(4px);
+      border-radius: 0.25rem;
       box-shadow: 0 0 6.4px 4px $shadow-light;
       background-color: get-color(white);
 
@@ -66,7 +66,7 @@
       }
 
       td {
-        padding: rem(8px) rem(16px);
+        padding: 0.5rem 1rem;
         overflow: hidden;
         vertical-align: middle;
         text-overflow: ellipsis;
@@ -84,8 +84,8 @@
     display: inline-flex;
     position: relative;
     flex: auto;
-    padding: rem(4px);
-    padding-bottom: rem(32px);
+    padding: 0.25rem;
+    padding-bottom: 2rem;
   }
 
   &__no-results {

--- a/src/components/MaDatagrid/components/MaDatagridLoader.scss
+++ b/src/components/MaDatagrid/components/MaDatagridLoader.scss
@@ -1,7 +1,7 @@
 .loader-row {
   position: relative;
   opacity: 0;
-  height: rem(66px);
+  height: 4rem;
   animation: aniVertical 3s ease;
   animation-iteration-count: infinite;
   animation-fill-mode: forwards;
@@ -35,10 +35,10 @@
 }
 
 .loader-item {
-  margin-bottom: rem(8px);
-  border-radius: rem(16px);
+  margin-bottom: 0.5rem;
+  border-radius: 1rem;
   background: lighten(get-color(black), 85%);
-  height: rem(8px);
+  height: 0.5rem;
 
   &:last-child {
     margin-bottom: 0;

--- a/src/components/MaOption/MaOption.scss
+++ b/src/components/MaOption/MaOption.scss
@@ -18,13 +18,13 @@
       }
 
       &:checked ~ .indicator {
-        $indicator-svg-size: rem(13px);
+        $indicator-svg-size: 0.75rem;
 
         &::before {
           display: block;
           position: absolute;
-          top: rem(5px);
-          right: rem(5px);
+          top: 5px;
+          right: 5px;
           z-index: 1;
           background-image: url('../../assets/icons/tick.svg');
           background-size: $indicator-svg-size $indicator-svg-size;
@@ -61,7 +61,7 @@
     right: 0;
     transition: border-color 0.33s, border-width 0.33s, background-color 0.33s;
     border: 0 solid transparent;
-    border-radius: rem(8px);
+    border-radius: 0.5rem;
     background-color: transparent;
     width: $indicator-size;
     height: $indicator-size;
@@ -74,8 +74,8 @@
 
     &::after {
       position: absolute;
-      top: rem(-1px);
-      right: rem(-1px);
+      top: -1px;
+      right: -1px;
       transition: border-color 0.33s;
       border-width: 0 $indicator-size $indicator-size 0;
       border-style: solid;
@@ -89,10 +89,10 @@
   .description {
     flex: 1;
     border: 1px solid get-color(gray, light);
-    border-radius: rem(8px);
+    border-radius: 0.5rem;
     box-shadow: 0 0 8px 6px $shadow-light;
     background-color: get-color(white);
-    padding: rem(24px);
+    padding: 1.5rem;
   }
 }
 

--- a/src/components/MaOption/MaOptionCheckbox.scss
+++ b/src/components/MaOption/MaOptionCheckbox.scss
@@ -1,17 +1,22 @@
 .ma-option--checkbox {
+  --indicator-size: 1rem;
+
   .indicator {
     position: absolute;
-    top: rem(2px);
+    top: 2px;
     left: 0;
     transition: border 0.4s, background-color 0.33s;
     border: 1px solid get-color(gray, light);
     background-color: get-color(white);
-    width: rem(16px);
-    height: rem(16px);
+    width: var(--indicator-size);
+    height: var(--indicator-size);
   }
 
   .description {
-    padding-left: rem(22px);
+    // The .indicator is absolute-positioned, so we need to make room for the
+    // description.
+    padding-left: calc(var(--indicator-size) + 0.5rem);
+
     line-height: 1.3;
     color: get-color(gray, dark);
   }
@@ -23,19 +28,21 @@
 
     &:checked ~ .indicator,
     &:disabled ~ .indicator {
-      border: 0;
+      border: 1px solid;
       background-image: url('../../assets/icons/tick.svg');
-      background-position: rem(3px) rem(3px);
+      background-position: 2px 2px;
       background-repeat: no-repeat;
-      background-size: rem(10px) rem(10px);
+      background-size: 12px 12px;
     }
 
     &:checked ~ .indicator {
       background-color: get-color(pink);
+      border-color: get-color(pink);
     }
 
     &:disabled ~ .indicator {
       background-color: get-color(gray);
+      border-color: get-color(gray);
       cursor: not-allowed;
     }
 

--- a/src/components/MaOption/MaOptionRadio.scss
+++ b/src/components/MaOption/MaOptionRadio.scss
@@ -9,13 +9,13 @@
     border-radius: 50%;
     background-color: get-color(white);
     cursor: pointer;
-    width: rem(16px);
-    height: rem(16px);
+    width: 1rem;
+    height: 1rem;
     user-select: none;
   }
 
   .description {
-    padding-left: rem(6px);
+    padding-left: 0.5rem;
   }
 
   .input {

--- a/src/components/MaPagination/MaPagination.scss
+++ b/src/components/MaPagination/MaPagination.scss
@@ -28,7 +28,7 @@
 .ma-pagination__separator {
   align-self: flex-end;
   justify-content: center;
-  padding-bottom: rem(8px);
+  padding-bottom: 0.5rem;
   text-align: center;
   color: get-color(gray, dark);
 }

--- a/src/components/MaPill/MaPill.scss
+++ b/src/components/MaPill/MaPill.scss
@@ -2,10 +2,11 @@
   @include font-weight(semibold);
 
   display: inline-block;
-  border-radius: rem(8px);
-  padding: rem(6px) rem(12px);
+  line-height: 1;
+  border-radius: 0.5rem;
+  padding: 0.5rem 1rem;
   width: auto;
-  font-size: rem(14px);
+  font-size: 0.875rem;
 
   &--green {
     background-color: get-color(green, light);
@@ -23,7 +24,7 @@
   }
 
   &--gray {
-    border: 1px solid get-color(gray);
+    box-shadow: inset 0 0 0 1px get-color(gray);
     background-color: get-color(gray, light);
     color: get-color(gray, dark);
   }

--- a/src/components/MaRange/MaRange.scss
+++ b/src/components/MaRange/MaRange.scss
@@ -1,12 +1,12 @@
-$ma-range-height: rem(16px);
-$ma-range-radius: rem(10px);
+$ma-range-height: 1rem;
+$ma-range-radius: 10px;
 $ma-range-transition: 0.2s;
-$ma-range-bullet-size: rem(4px);
+$ma-range-bullet-size: 4px;
 
 .ma-range {
   position: relative;
-  margin-top: rem(4px);
-  padding-bottom: rem(32px);
+  margin-top: 4px;
+  padding-bottom: 2rem;
 
   &::after {
     display: block;
@@ -24,7 +24,7 @@ $ma-range-bullet-size: rem(4px);
   &__step {
     position: absolute;
     cursor: pointer;
-    padding-top: rem(21px);
+    padding-top: 21px;
     color: get-color(gray);
     user-select: none;
   }
@@ -37,8 +37,8 @@ $ma-range-bullet-size: rem(4px);
   &__native-element {
     appearance: none;
     position: absolute;
-    top: rem(-2px);
-    left: rem(-10px);
+    top: -2px;
+    left: -10px;
     opacity: 0;
     z-index: 1;
     outline: none;
@@ -72,7 +72,7 @@ $ma-range-bullet-size: rem(4px);
   &__bullet {
     display: inline-block;
     position: absolute;
-    top: rem(6px);
+    top: 6px;
     left: 0%;
     z-index: 2;
     border-radius: 50%;

--- a/src/components/MaSelect/MaSelect.scss
+++ b/src/components/MaSelect/MaSelect.scss
@@ -3,10 +3,10 @@
   flex-direction: column;
   width: 100%;
   color: get-color(gray, dark);
-  font-size: rem(16px);
+  font-size: 1rem;
 
   &__label {
-    margin-bottom: rem(4px);
+    margin-bottom: 0.25rem;
   }
 
   &__field {
@@ -19,11 +19,10 @@
     background-position: calc(100% - 12px) 50%;
     background-repeat: no-repeat;
     background-size: 12px 8px;
-    padding: 0 rem(32px) 0 rem(8px);
+    padding: 0 2rem 0 0.5rem;
     width: 100%;
-    height: rem(36px);
+    height: 2.25rem;
     color: get-color(gray, dark);
-    font-size: rem(16px);
 
     &:focus {
       outline: 2px solid get-color(pink, light);
@@ -70,8 +69,8 @@
   }
 
   &__error-message {
-    margin-top: rem(4px);
+    margin-top: 0.25rem;
     color: get-color(pink, dark);
-    font-size: rem(14px);
+    font-size: 0.875rem;
   }
 }

--- a/src/components/MaSidebar/MaSidebar.scss
+++ b/src/components/MaSidebar/MaSidebar.scss
@@ -6,7 +6,7 @@
   z-index: 9999;
   margin: 0;
   background-color: get-color(white);
-  min-width: rem(216px);
+  min-width: 13.5rem;
   overflow-x: hidden;
 
   &--attached {

--- a/src/components/MaTextField/MaTextField.scss
+++ b/src/components/MaTextField/MaTextField.scss
@@ -7,7 +7,7 @@
   &__label-wrapper {
     display: flex;
     align-items: center;
-    margin-bottom: rem(4px);
+    margin-bottom: 0.25rem;
   }
 
   &__label {
@@ -16,7 +16,7 @@
 
   &__input-wrapper {
     display: flex;
-    height: rem(36px);
+    height: 2.25rem;
   }
 
   &__input {
@@ -24,10 +24,10 @@
     transition: border 0.2s ease;
     border: 1px solid get-color(gray, light);
     background-color: get-color(white);
-    padding: 0 rem(8px);
+    padding: 0 0.5rem;
     max-width: 100%;
     height: 100%;
-    font-size: rem(16px);
+    font-size: 1rem;
 
     &:focus {
       outline: 2px solid get-color(pink, light);
@@ -54,7 +54,7 @@
       background-position: calc(100% - 8px) center;
       background-repeat: no-repeat;
       background-size: 20px;
-      padding-right: rem(40px);
+      padding-right: 2.5rem;
 
       &:focus,
       &:active {
@@ -64,8 +64,8 @@
   }
 
   &__error-message {
-    margin-top: rem(4px);
+    margin-top: 0.25rem;
     color: get-color(pink, dark);
-    font-size: rem(14px);
+    font-size: 0.875rem;
   }
 }

--- a/src/components/MaTextField/MaTextField.stories.js
+++ b/src/components/MaTextField/MaTextField.stories.js
@@ -151,7 +151,7 @@ export const TextFieldWithIcon = () => {
   }
 }
 
-export const ErroredTextField = () => {
+export const TextFieldWithError = () => {
   const errorMessage = text('Error msg', 'You have an error')
   const label = text('Label', 'Label')
 


### PR DESCRIPTION
On the quest to progressively reduce the usage of SCSS, this PR removes the dreaded `rem()` function, which was not that helpful.

Notice that the function is still exposed for consumers to use, so this is not a breaking change.

Also, I tweaked some values to make them closer to what's in the Figma file of the Design System, so I think we could issue a release.