### PR TITLE
fix(perf): Remove (unwanted) support for any IE browser

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,3 +1,4 @@
 > 1%
 last 2 versions
 not dead
+not ie > 8


### PR DESCRIPTION
Looks like we were still supporting IE here in margarita even though it is not a browser we decided to support.

Before:


![Captura de Pantalla 2021-01-29 a les 13 33 58](https://user-images.githubusercontent.com/9197791/106275939-03b74d80-6237-11eb-8dd5-52e3e5edc40c.png)


After:


![Captura de Pantalla 2021-01-29 a les 13 35 25](https://user-images.githubusercontent.com/9197791/106275934-00bc5d00-6237-11eb-9a63-e04576f4bf8f.png)


🚀 

---

FYI, list of currently supported browsers (at least in margarita):

```bash
$ npx browserslist                        

and_chr 86
and_ff 82
and_qq 10.4
and_uc 12.12
android 81
baidu 7.12
chrome 86
chrome 85
edge 86
edge 85
firefox 82
firefox 81
ios_saf 14
ios_saf 13.4-13.7
ios_saf 12.2-12.4
kaios 2.5
op_mini all
op_mob 59
opera 72
opera 71
safari 14
safari 13.1
samsung 12.0
samsung 11.1-11.2
```