### PR TITLE
feat(Stack): Add fill value for align prop

### DIFF
--- a/src/components/MaStack/MaStack.spec.js
+++ b/src/components/MaStack/MaStack.spec.js
@@ -22,6 +22,12 @@ describe('Stack', () => {
     expect(contentWrapper).toHaveClass('stack--align-right')
   })
 
+  test(`alignment class defaults to 'fill'`, () => {
+    const { contentWrapper } = renderComponent({ space: 'medium' })
+
+    expect(contentWrapper).toHaveClass('stack--align-fill')
+  })
+
   test('adds alignment classes from array', () => {
     const { contentWrapper } = renderComponent({ align: ['center', 'right'] })
 

--- a/src/components/MaStack/MaStack.vue
+++ b/src/components/MaStack/MaStack.vue
@@ -1,5 +1,9 @@
 <template>
-  <div :style="styles" :class="classes" class="stack">
+  <div
+    :style="styles"
+    :class="[`stack--align-${responsiveAlign}`]"
+    class="stack"
+  >
     <slot />
   </div>
 </template>
@@ -7,21 +11,29 @@
 <script>
 import { responsivePropValidator } from '@margarita/utils/responsivePropValidator'
 import { spacing } from '../../tokens'
-const alignment = ['left', 'center', 'right']
+const alignment = ['left', 'center', 'right', 'fill']
 
 export default {
   name: 'MaStack',
 
   props: {
+    /**
+     * Sets the space gap between children.
+     * @values none, xsmall, small, medium, large, xlarge, 2x-large, 3x-large, 4x-large, 5x-large, 6x-large
+     */
     space: {
       type: [Array, String],
       required: true,
       validator: responsivePropValidator(Object.keys(spacing)),
     },
 
+    /**
+     * Set the children alignment. Defaults to fill.
+     * @values left, center, right, fill
+     */
     align: {
       type: [Array, String],
-      default: null,
+      default: 'fill',
       validator: responsivePropValidator(alignment),
     },
   },
@@ -35,12 +47,6 @@ export default {
       return this.$layout.getResponsivePropValue(this.align)
     },
 
-    classes() {
-      return {
-        [`stack--align-${this.responsiveAlign}`]: this.align,
-      }
-    },
-
     styles() {
       return { gap: spacing[this.responsiveSpace] }
     },
@@ -52,6 +58,10 @@ export default {
 .stack {
   display: grid;
   grid-auto-flow: row;
+}
+
+.stack--align-fill {
+  justify-items: stretch;
 }
 
 .stack--align-left {

--- a/vetur/attributes.json
+++ b/vetur/attributes.json
@@ -180,10 +180,26 @@
     "type": "boolean"
   },
   "ma-stack/space": {
-    "type": "array|string"
+    "type": "array|string",
+    "description": "Sets the space gap between children.",
+    "options": [
+      "none",
+      "xsmall",
+      "small",
+      "medium",
+      "large",
+      "xlarge",
+      "2x-large",
+      "3x-large",
+      "4x-large",
+      "5x-large",
+      "6x-large"
+    ]
   },
   "ma-stack/align": {
-    "type": "array|string"
+    "type": "array|string",
+    "description": "Set the children alignment. Defaults to fill.",
+    "options": ["left", "center", "right", "fill"]
   },
   "ma-text/tag": {
     "type": "string",


### PR DESCRIPTION
This PR adds a `fill` value for the `align` prop on MaStack.

Thing is, align prop is currently optional and sets its default value to null. Turns out not setting any value yields a different behavior that setting `align="left"`, which _looks like_ the default value.

[See this codesandbox](https://codesandbox.io/s/cool-snyder-ph62f?file=/src/App.vue) to check what's going on.

The simplest way of handling this situation without introducing any breaking changes is by making the currently null value explicit – that is, creating a prop value that yields the same result (justify-items: stretch) as not setting the prop whatsoever. This makes the component more explicit and allows for responsive behaviors (`:align="[ 'fill', 'left' ]"`)