### PR TITLE
docs: Add Spacing tokens doc

### DIFF
--- a/docs/tokens/spacing.stories.mdx
+++ b/docs/tokens/spacing.stories.mdx
@@ -1,0 +1,23 @@
+import { Meta, Story } from '@storybook/addon-docs/blocks';
+import { spacing } from '../../src/tokens'
+import MaDatagrid from '../../src/components/MaDatagrid'
+
+<Meta title="Tokens/Spacing" />
+
+export const tokenRows = Object.entries(spacing).map(([tokenName,tokenValue])=>{
+    return {name:tokenName,value:tokenValue}
+})
+
+export const tokenColumns = [{name:'Spacing name',value:'name'},{name:'Spacing value',value:'value'}]
+
+export const Template = (args) => <MaDatagrid {...args } />
+
+# Spacing
+This is our values for spacing vertically and horizontally layout elements, based on 8px-grid. 
+
+<Story name="spacing" args={{
+     :rows: tokenRows
+     :columns: tokenColumns
+  }}>
+    {Template.bind({})}
+  </Story>

--- a/docs/tokens/spacing.stories.mdx
+++ b/docs/tokens/spacing.stories.mdx
@@ -5,7 +5,7 @@ import { spacing } from '../../src/tokens'
 
 # Spacing
 
-Consistent spacing creates visual balance, rythm and visual understanding that makes the user interface (UI) easier for our users to scan.
+Consistent spacing creates visual balance, rythm and visual understanding that makes the user interface (UI) easier to scan. All spacing is done in increments of 8 pixels, which is the basic unit of measurement for spacing.
 
 ---
 
@@ -15,11 +15,7 @@ We use incrementally measured spacing to create harmonious arrangements of compo
 
 #### Precise but flexible
 
-Beyond mathematical precision, spacing also reacts to the objects it surrounds, giving more space to larger objects, less to small. Optical adjustments can also be made if an element looks off and the spacing needs a nudge to make things feel right.
-
-#### The spacing system
-
-All spacing for components and typography is done in increments of 4 pixels. This forms the basic unit of measurement for spacing.
+Spacing also reacts to the objects it surrounds. Optical adjustments can also be made if an element looks off and the spacing needs a nudge to make things feel right.
 
 ## Layout Spacing
 
@@ -39,6 +35,6 @@ All spacing for components and typography is done in increments of 4 pixels. Thi
 
 ## How to choose spacing
 
-Use less space between small components, or components that share a close functional relationship.
+Use less space between small components, or components that share a close functional relationship, for example, for buttons that have a similar purpose.
 
-Coordinate small and large values, along with structural components (like Home cards), to create visual groupings of related things. This helps merchants understand the interface and more easily find what they’re looking for. For screens with specialized layouts, adjust overall spacing based on the density of the content. For example, a simple login screen on desktop display has more room to breathe, so more space can be used.
+Coordinate small and large values, along with structural components to create visual groupings of related things. This helps our users understand the interface and more easily find what they’re looking for.

--- a/docs/tokens/spacing.stories.mdx
+++ b/docs/tokens/spacing.stories.mdx
@@ -22,10 +22,11 @@ Spacing also reacts to the objects it surrounds. Optical adjustments can also be
 <div style={{display: 'grid', gridAutoFlow: 'rows', gap: '2rem', marginTop: '1.5rem'}}>
 {
   Object.entries(spacing).map(([tokenName,tokenValue]) => (
-    <div style={{display: 'grid', gridAutoFlow: 'column', gap: '3rem', maxWidth: '600px', alignItems: 'center', gridTemplateColumns: '4rem 11rem 4rem'}}>
+    <div style={{display: 'grid', gridAutoFlow: 'column', gap: '3rem', maxWidth: '600px', alignItems: 'center', gridTemplateColumns: '4rem 11rem 4rem 3rem'}}>
       <span>{tokenName}</span>
       <div style={{width: tokenValue, height: tokenValue, backgroundColor: 'var(--color-gray-light)', justifySelf: 'center'}}/>
       <span>{tokenValue}</span>
+      <span>{Number(tokenValue.split('rem')[0])*16}px</span>
     </div>
     )
   )

--- a/docs/tokens/spacing.stories.mdx
+++ b/docs/tokens/spacing.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta } from '@storybook/addon-docs/blocks';
+import { Meta } from '@storybook/addon-docs/blocks'
 import { spacing } from '../../src/tokens'
 
 <Meta title="Tokens/Spacing" />
@@ -19,20 +19,38 @@ Spacing also reacts to the objects it surrounds. Optical adjustments can also be
 
 ## Layout Spacing
 
-<div style={{display: 'grid', gridAutoFlow: 'rows', gap: '2rem', marginTop: '1.5rem'}}>
-{
-  Object.entries(spacing).map(([tokenName,tokenValue]) => (
-    <div style={{display: 'grid', gridAutoFlow: 'column', gap: '3rem', maxWidth: '600px', alignItems: 'center', gridTemplateColumns: '4rem 11rem 4rem 3rem'}}>
+<div
+  style={{
+    display: 'grid',
+    gridAutoFlow: 'rows',
+    gap: '2rem',
+    marginTop: '1.5rem',
+  }}
+>
+  {Object.entries(spacing).map(([tokenName, tokenValue]) => (
+    <div
+      style={{
+        display: 'grid',
+        gridAutoFlow: 'column',
+        gap: '3rem',
+        maxWidth: '600px',
+        alignItems: 'center',
+        gridTemplateColumns: '4rem 11rem 4rem',
+      }}
+    >
       <span>{tokenName}</span>
-      <div style={{width: tokenValue, height: tokenValue, backgroundColor: 'var(--color-gray-light)', justifySelf: 'center'}}/>
+      <div
+        style={{
+          width: tokenValue,
+          height: tokenValue,
+          backgroundColor: 'var(--color-gray-light)',
+          justifySelf: 'center',
+        }}
+      />
       <span>{tokenValue}</span>
-      <span>{Number(tokenValue.split('rem')[0])*16}px</span>
     </div>
-    )
-  )
-}
+  ))}
 </div>
-
 
 ## How to choose spacing
 

--- a/docs/tokens/spacing.stories.mdx
+++ b/docs/tokens/spacing.stories.mdx
@@ -1,23 +1,44 @@
-import { Meta, Story } from '@storybook/addon-docs/blocks';
+import { Meta } from '@storybook/addon-docs/blocks';
 import { spacing } from '../../src/tokens'
-import MaDatagrid from '../../src/components/MaDatagrid'
 
 <Meta title="Tokens/Spacing" />
 
-export const tokenRows = Object.entries(spacing).map(([tokenName,tokenValue])=>{
-    return {name:tokenName,value:tokenValue}
-})
-
-export const tokenColumns = [{name:'Spacing name',value:'name'},{name:'Spacing value',value:'value'}]
-
-export const Template = (args) => <MaDatagrid {...args } />
-
 # Spacing
-This is our values for spacing vertically and horizontally layout elements, based on 8px-grid. 
 
-<Story name="spacing" args={{
-     :rows: tokenRows
-     :columns: tokenColumns
-  }}>
-    {Template.bind({})}
-  </Story>
+Consistent spacing creates visual balance, rythm and visual understanding that makes the user interface (UI) easier for our users to scan.
+
+---
+
+#### Create visual rhythm
+
+We use incrementally measured spacing to create harmonious arrangements of components and text. This gives the elements a predictable rhythm, which makes the experience as a whole feel intentional and well designed.
+
+#### Precise but flexible
+
+Beyond mathematical precision, spacing also reacts to the objects it surrounds, giving more space to larger objects, less to small. Optical adjustments can also be made if an element looks off and the spacing needs a nudge to make things feel right.
+
+#### The spacing system
+
+All spacing for components and typography is done in increments of 4 pixels. This forms the basic unit of measurement for spacing.
+
+## Layout Spacing
+
+<div style={{display: 'grid', gridAutoFlow: 'rows', gap: '2rem', marginTop: '1.5rem'}}>
+{
+  Object.entries(spacing).map(([tokenName,tokenValue]) => (
+    <div style={{display: 'grid', gridAutoFlow: 'column', gap: '3rem', maxWidth: '600px', alignItems: 'center', gridTemplateColumns: '4rem 11rem 4rem'}}>
+      <span>{tokenName}</span>
+      <div style={{width: tokenValue, height: tokenValue, backgroundColor: 'var(--color-gray-light)', justifySelf: 'center'}}/>
+      <span>{tokenValue}</span>
+    </div>
+    )
+  )
+}
+</div>
+
+
+## How to choose spacing
+
+Use less space between small components, or components that share a close functional relationship.
+
+Coordinate small and large values, along with structural components (like Home cards), to create visual groupings of related things. This helps merchants understand the interface and more easily find what they’re looking for. For screens with specialized layouts, adjust overall spacing based on the density of the content. For example, a simple login screen on desktop display has more room to breathe, so more space can be used.

--- a/src/components/MaHeading/MaHeading.vue
+++ b/src/components/MaHeading/MaHeading.vue
@@ -24,7 +24,7 @@ export default {
     },
 
     /**
-     * Sets the text element size accroding to our Design System
+     * Sets the text element size according to our Design System
      * @values xsmall, small, medium, large, xlarge
      */
     size: {

--- a/src/components/MaStack/MaStack.vue
+++ b/src/components/MaStack/MaStack.vue
@@ -19,6 +19,8 @@ export default {
   props: {
     /**
      * Sets the space gap between children.
+     *
+     * [Spacing tokens documentation](https://holaluz.github.io/margarita/?path=/story/tokens-spacing--page)
      * @values none, xsmall, small, medium, large, xlarge, 2x-large, 3x-large, 4x-large, 5x-large, 6x-large
      */
     space: {

--- a/src/components/MaText/MaText.vue
+++ b/src/components/MaText/MaText.vue
@@ -28,7 +28,7 @@ export default {
     },
 
     /**
-     * Sets the text element size accroding to our Design System
+     * Sets the text element size according to our Design System
      */
     size: {
       type: String,

--- a/vetur/attributes.json
+++ b/vetur/attributes.json
@@ -65,7 +65,7 @@
   },
   "ma-heading/size": {
     "type": "string",
-    "description": "Sets the text element size accroding to our Design System",
+    "description": "Sets the text element size according to our Design System",
     "options": ["xsmall", "small", "medium", "large", "xlarge"]
   },
   "ma-heading/tone": {
@@ -213,7 +213,7 @@
   },
   "ma-stack/space": {
     "type": "array|string",
-    "description": "Sets the space gap between children.",
+    "description": "Sets the space gap between children.\n\n[Spacing tokens documentation](https://holaluz.github.io/margarita/?path=/story/tokens-spacing--page)",
     "options": [
       "none",
       "xsmall",
@@ -240,7 +240,7 @@
   },
   "ma-text/size": {
     "type": "string",
-    "description": "Sets the text element size accroding to our Design System",
+    "description": "Sets the text element size according to our Design System",
     "options": ["xsmall", "small", "medium"]
   },
   "ma-text/italic": {


### PR DESCRIPTION
Documentation page link -> https://601199d127273f0021b037b0-qyeivtvayb.chromatic.com/?path=/story/tokens-spacing--page

### Pros:
- Same page for 'canvas' and 'docs' page -> just maintain one file/documentation (shall we do the same with the colors and the other tokens?)

### Cons?
- Still need to figure out how to use our components in MDX (I would like to use `MaStack` here) 🆘 

### Quick win:
Stop checking on `margarita` the relation between token/prop namings and actual spacing size 💯 

![Screen Shot 2021-02-10 at 11 18 46](https://user-images.githubusercontent.com/25011566/107497983-81624e00-6b93-11eb-8cbb-458477ab0cb9.png)
