### PR TITLE
fix: Add missing top placement and default z-index for Modal

### DIFF
--- a/src/components/MaModal/MaModal.css
+++ b/src/components/MaModal/MaModal.css
@@ -10,6 +10,7 @@
 .modal {
   position: fixed;
   left: 50%;
+  top: 50%;
   transform: translate(-50%, -50%);
   width: 96vw; /* so that it doesn't reach end of viewport */
 

--- a/src/components/MaModal/MaModal.css
+++ b/src/components/MaModal/MaModal.css
@@ -1,3 +1,13 @@
+.modal-wrapper {
+  position: relative;
+
+  /**
+   * TODO: Normalize z-indexes values across HL. For instance, this one is set
+   * to 101 to trump CMB's z-index of 100.
+   */
+  z-index: 101;
+}
+
 .modal-overlay {
   position: fixed;
   background-color: var(--shadow-dark);

--- a/src/components/MaModal/MaModal.vue
+++ b/src/components/MaModal/MaModal.vue
@@ -5,7 +5,7 @@
     </div>
     <ma-modal-portal>
       <transition name="modal-transition" @after-leave="closeModal">
-        <div v-if="showModal">
+        <div v-if="showModal" class="modal-wrapper">
           <div
             class="modal-overlay"
             data-testid="overlay"


### PR DESCRIPTION
Weirdly enough, Modal works fine on Storybook, but looks like it is not properly placed when used somewhere else ([here]( https://deploy-preview-379--maitai.netlify.app/es/)).

I simply added the same `top` value the animation was setting – but looks like it does the trick in Maitai. It displays the Modal where it belongs while also animating it.

Re z-index, we discussed this is the simplest solution for now. I've left a comment to make sure we understand this is a quick&dirty fix, and not something we should rely on ;)

Any additional test would be appreciated!