### PR TITLE
feat: Add layout components

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -8,7 +8,6 @@ export const parameters = {
   layout: 'centered',
 
   controls: { expanded: true },
-
   options: {
     storySort: {
       order: [

--- a/docs/components/MaLayout.docs.mdx
+++ b/docs/components/MaLayout.docs.mdx
@@ -18,14 +18,14 @@ This prop is a string, which can have the following characters:
 
 ```js
 // Renders a single, full-width column
-<ma-layout="12">...</ma-layout>
+<ma-layout columns="12">...</ma-layout>
 
 // Renders a two-column layout: one with 11/12 of the total width, and the other with the remaining 1/12.
-<ma-layout="11 1">...</ma-layout>
+<ma-layout columns="11 1">...</ma-layout>
 
 // Renders a layout with two rows: the first one where the element has full width,
 // and the second one with the rest of the children in a single row.
-<ma-layout="12 - *">...</ma-layout>
+<ma-layout columns="12 - *">...</ma-layout>
 ```
 
 Since it's a bit hard to visualize by text, here are some examples and the value of `columns` used to achieve it.

--- a/docs/components/MaLayout.docs.mdx
+++ b/docs/components/MaLayout.docs.mdx
@@ -1,0 +1,35 @@
+import { Story } from '@storybook/addon-docs/blocks'
+
+# Layout Component
+
+## The columns prop
+
+The layout component generates a combination of columns an rows equal to what its defined in the `columns` prop.
+
+This prop is a string, which can have this characters:
+
+- **An integer from (1 to 12):** signifies the width that a column will fill in a 12-col layout.
+- **An hyphen (-):** signifies an end of a row.
+- **The autoflow operator (\*):** signifies that the rest of the elements of the div will all be fit in the same row.
+
+So, for example, a value of `12` will mean that all the direct children of the `<ma-layout>` will all occupy a full width column (AKA stack).
+
+A value of `11 1` will mean that the direct children will be classified in rows of 2 columns: one of size 11 and the other of size 1.
+
+A value of `12 - *` will mean that there will be 2 rows, one full width and the other with the rest of the direct children of the `<ma-layout>`.
+
+Since it's a bit hard to visualize by text, here are some examples and the value of `columns` used to achieve it.
+
+## Examples:
+
+<Story id="layout-layout-examples--example-1" />
+<Story id="layout-layout-examples--example-2" />
+<Story id="layout-layout-examples--example-3" />
+<Story id="layout-layout-examples--example-4" />
+<Story id="layout-layout-examples--example-5" />
+<Story id="layout-layout-examples--example-6" />
+<Story id="layout-layout-examples--example-7" />
+<Story id="layout-layout-examples--example-8" />
+<Story id="layout-layout-examples--example-9" />
+<Story id="layout-layout-examples--example-10" />
+<Story id="layout-layout-examples--example-11" />

--- a/docs/components/MaLayout.docs.mdx
+++ b/docs/components/MaLayout.docs.mdx
@@ -2,25 +2,35 @@ import { Story } from '@storybook/addon-docs/blocks'
 
 # Layout Component
 
+The Layout component is the fundamental piece to create UI layouts.
+
 ## The columns prop
 
-The layout component generates a combination of columns an rows equal to what its defined in the `columns` prop.
+The layout component generates a combination of columns an rows using the `columns` prop.
 
-This prop is a string, which can have this characters:
+This prop is a string, which can have the following characters:
 
 - **An integer from (1 to 12):** signifies the width that a column will fill in a 12-col layout.
 - **An hyphen (-):** signifies an end of a row.
 - **The autoflow operator (\*):** signifies that the rest of the elements of the div will all be fit in the same row.
 
-So, for example, a value of `12` will mean that all the direct children of the `<ma-layout>` will all occupy a full width column (AKA stack).
+## Quick examples
 
-A value of `11 1` will mean that the direct children will be classified in rows of 2 columns: one of size 11 and the other of size 1.
+```js
+// Renders a single, full-width column
+<ma-layout="12">...</ma-layout>
 
-A value of `12 - *` will mean that there will be 2 rows, one full width and the other with the rest of the direct children of the `<ma-layout>`.
+// Renders a two-column layout: one with 11/12 of the total width, and the other with the remaining 1/12.
+<ma-layout="11 1">...</ma-layout>
+
+// Renders a layout with two rows: the first one where the element has full width,
+// and the second one with the rest of the children in a single row.
+<ma-layout="12 - *">...</ma-layout>
+```
 
 Since it's a bit hard to visualize by text, here are some examples and the value of `columns` used to achieve it.
 
-## Examples:
+## Full examples
 
 <Story id="layout-layout-examples--example-1" />
 <Story id="layout-layout-examples--example-2" />

--- a/docs/components/MaLayout.docs.mdx
+++ b/docs/components/MaLayout.docs.mdx
@@ -43,3 +43,7 @@ Since it's a bit hard to visualize by text, here are some examples and the value
 <Story id="layout-layout-examples--example-9" />
 <Story id="layout-layout-examples--example-10" />
 <Story id="layout-layout-examples--example-11" />
+<Story id="layout-layout-examples--example-12" />
+<Story id="layout-layout-examples--example-13" />
+<Story id="layout-layout-examples--example-14" />
+<Story id="layout-layout-examples--example-15" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -7188,17 +7188,6 @@
             }
           }
         },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
         "chownr": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
@@ -7591,56 +7580,6 @@
                 "@types/json-schema": "^7.0.5",
                 "ajv": "^6.12.4",
                 "ajv-keywords": "^3.5.2"
-              }
-            }
-          }
-        },
-        "vue-loader-v16": {
-          "version": "npm:vue-loader@16.1.2",
-          "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.1.2.tgz",
-          "integrity": "sha512-8QTxh+Fd+HB6fiL52iEVLKqE9N1JSlMXLR92Ijm6g8PZrwIxckgpqjPDWRP5TWxdiPaHR+alUWsnu1ShQOwt+Q==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "chalk": "^4.1.0",
-            "hash-sum": "^2.0.0",
-            "loader-utils": "^2.0.0"
-          },
-          "dependencies": {
-            "big.js": {
-              "version": "5.2.2",
-              "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-              "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
-              "dev": true,
-              "optional": true
-            },
-            "emojis-list": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-              "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
-              "dev": true,
-              "optional": true
-            },
-            "json5": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-              "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "minimist": "^1.2.5"
-              }
-            },
-            "loader-utils": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-              "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "big.js": "^5.2.2",
-                "emojis-list": "^3.0.0",
-                "json5": "^2.1.2"
               }
             }
           }
@@ -36368,6 +36307,94 @@
         "loader-utils": "^1.1.0",
         "vue-hot-reload-api": "^2.3.0",
         "vue-style-loader": "^4.1.0"
+      }
+    },
+    "vue-loader-v16": {
+      "version": "npm:vue-loader@16.1.2",
+      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.1.2.tgz",
+      "integrity": "sha512-8QTxh+Fd+HB6fiL52iEVLKqE9N1JSlMXLR92Ijm6g8PZrwIxckgpqjPDWRP5TWxdiPaHR+alUWsnu1ShQOwt+Q==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "hash-sum": "^2.0.0",
+        "loader-utils": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true,
+          "optional": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true,
+          "optional": true
+        },
+        "hash-sum": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-2.0.0.tgz",
+          "integrity": "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg==",
+          "dev": true,
+          "optional": true
+        },
+        "loader-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "vue-style-loader": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -36052,6 +36052,11 @@
         }
       }
     },
+    "vue-functional-data-merge": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vue-functional-data-merge/-/vue-functional-data-merge-3.1.0.tgz",
+      "integrity": "sha512-leT4kdJVQyeZNY1kmnS1xiUlQ9z1B/kdBFCILIjYYQDqZgLqCLa0UhjSSeRX6c3mUe6U5qYeM8LrEqkHJ1B4LA=="
+    },
     "vue-hot-reload-api": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "@linusborg/vue-simple-portal": "^0.1.5",
     "sass-mq": "^5.0.0",
     "snarkdown": "^2.0.0",
-    "vue": "^2.6.12"
+    "vue": "^2.6.12",
+    "vue-functional-data-merge": "^3.1.0"
   },
   "devDependencies": {
     "@babel/plugin-proposal-optional-chaining": "^7.12.7",

--- a/src/components/MaColumns/MaColumns.spec.js
+++ b/src/components/MaColumns/MaColumns.spec.js
@@ -1,0 +1,87 @@
+import { render } from '@margarita/margarita-test-utils'
+import MaColumns from './MaColumns'
+import { spacing } from '../../tokens'
+
+describe('MaColumns', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementationOnce(() => {})
+  })
+
+  test('adds spacing styles', () => {
+    const { contentWrapper } = renderComponent({ gap: 'large' })
+    expect(contentWrapper).toHaveStyle({ gap: spacing.large })
+  })
+
+  test('adds spacing styles from array', () => {
+    const { contentWrapper } = renderComponent({ gap: ['small', 'large'] })
+    expect(contentWrapper).toHaveStyle({ gap: spacing.small })
+  })
+
+  test('adds justify styles', () => {
+    const { contentWrapper } = renderComponent({ justify: 'space-between' })
+    expect(contentWrapper).toHaveStyle({ justifyContent: 'space-between' })
+  })
+
+  test('adds vertical alignment class', () => {
+    const { contentWrapper } = renderComponent({ verticalAlign: 'end' })
+    expect(contentWrapper).toHaveClass('vertical-align-end')
+  })
+
+  test('warns if columns exceed 12 column layout', () => {
+    renderComponent({ columns: '6 6 6' })
+    expect(console.error).toHaveBeenCalledWith(
+      '[Layout Error] The row overflows the 12-column layout.'
+    )
+  })
+
+  test('warns if autoflow operator has other columns', () => {
+    renderComponent({ columns: '1 * 1' })
+    expect(console.error).toHaveBeenCalledWith(
+      '[Layout Error] The autoFlow operator (*) cannot have other columns in the row.'
+    )
+  })
+
+  test('warns if column is not an integer', () => {
+    renderComponent({ columns: '1 1.5' })
+    expect(console.error).toHaveBeenCalledWith(
+      '[Layout Error] Column #1 must be an integer.'
+    )
+  })
+
+  test('warns if column size is out of bounds', () => {
+    renderComponent({ columns: '-3' })
+    expect(console.error).toHaveBeenCalledWith(
+      '[Layout Error] Column #0 must have a value from 0 to 12.'
+    )
+  })
+
+  test('does not warn if columns are valid', () => {
+    renderComponent({ columns: '2 3 4' })
+    expect(console.error).not.toHaveBeenCalled()
+  })
+
+  test('adds auto flow if columns has autoFlow operator', () => {
+    const { contentWrapper } = renderComponent({ columns: '*' })
+    expect(contentWrapper).toHaveClass('hasAutoFlow')
+  })
+
+  test('adds correct column size', () => {
+    const { contentWrapper } = renderComponent({ columns: '6 6' })
+    expect(contentWrapper).toHaveAttribute(
+      'style',
+      expect.stringContaining('50%')
+    )
+  })
+})
+
+function renderComponent(props) {
+  const utils = render(MaColumns, {
+    props: { gap: 'small', columns: '12', ...props },
+    slots: { default: 'content' },
+  })
+  const contentWrapper = utils.getByText('content')
+  return {
+    ...utils,
+    contentWrapper,
+  }
+}

--- a/src/components/MaColumns/MaColumns.spec.js
+++ b/src/components/MaColumns/MaColumns.spec.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { render } from '@margarita/margarita-test-utils'
 import MaColumns from './MaColumns'
 import { spacing } from '../../tokens'

--- a/src/components/MaColumns/MaColumns.spec.js
+++ b/src/components/MaColumns/MaColumns.spec.js
@@ -63,7 +63,7 @@ describe('MaColumns', () => {
 
   test('adds auto flow if columns has autoFlow operator', () => {
     const { contentWrapper } = renderComponent({ columns: '*' })
-    expect(contentWrapper).toHaveClass('hasAutoFlow')
+    expect(contentWrapper).toHaveClass('has-auto-flow')
   })
 
   test('adds correct column size', () => {

--- a/src/components/MaColumns/MaColumns.stories.js
+++ b/src/components/MaColumns/MaColumns.stories.js
@@ -1,0 +1,59 @@
+import { spacing } from '@margarita/tokens'
+import MaColumns from './MaColumns'
+import docs from '../../../docs/components/MaColumns.docs.mdx'
+
+export default {
+  title: 'Layout/Columns',
+  component: MaColumns,
+  args: {
+    gap: 'small',
+    verticalAlign: 'start',
+    columns: ['12', '4 2 2 4', '3 2 4 3'],
+  },
+  argTypes: {
+    gap: {
+      control: {
+        type: 'select',
+        options: Object.keys(spacing),
+      },
+      description:
+        'If an array is passed, values will target the design system breakpoints',
+    },
+    verticalAlign: {
+      control: {
+        type: 'select',
+        options: ['space-around', 'space-between', 'start', 'end'],
+      },
+      description:
+        'If an array is passed, values will target the design system breakpoints',
+    },
+  },
+  parameters: {
+    docs: { page: docs },
+  },
+}
+
+const DemoBlock = {
+  template: `
+  <span style="width: 100%;background-color:#dcdcdc;text-align:center;color:#212121;padding:1rem 1rem;outline:1px solid #bbb">
+     <slot />
+  </span>
+  `,
+}
+
+const ColumnsTemplate = (args, { argTypes }) => ({
+  components: { DemoBlock },
+  props: Object.keys(argTypes),
+  template: `
+  <ma-stack space="large">
+    <ma-text>Columns: {{columns}}</ma-text>
+    <div style="background-color:#f1f1f1;width:400px">
+      <ma-columns v-bind="$props">
+        <demo-block v-for="i in 8" :key="i">{{ i }}</demo-block>
+      </ma-columns>
+    </div>
+  </ma-stack>
+  `,
+})
+
+export const Columns = ColumnsTemplate.bind({})

--- a/src/components/MaColumns/MaColumns.vue
+++ b/src/components/MaColumns/MaColumns.vue
@@ -20,8 +20,8 @@ export default {
      * Defines the columns layout.
      *
      * ```ts
-     * <ma-column columns="12">...</ma-column>
-     * <ma-column :columns="['4', '4', '4']">...</ma-column>
+     * <ma-column columns="6 6">...</ma-column>
+     * <ma-column :columns="['12', '4 4 4', '6 6']">...</ma-column>
      * ```
      */
     columns: {
@@ -113,7 +113,9 @@ function getResponsiveColumns({ parent, columns }) {
   const responsiveColumns = parent.$layout
     .getResponsivePropValue(columns)
     .split(' ')
-  validateColumnsProp({ columns: responsiveColumns })
+
+  validateColumnsProp(responsiveColumns)
+
   return responsiveColumns
 }
 
@@ -125,15 +127,20 @@ function hasAutoFlow({ columns }) {
 // https://stackoverflow.com/a/45092180
 function getGridTemplateColumns({ gap, columns }) {
   const gapDistribution = (columns.length - 1) / columns.length
+
   return columns
     .map((c) => {
       const widthPercentile = (c / columnCount) * 100
+      if (gap === spacing.none || gapDistribution === 0) {
+        return `${widthPercentile}%`
+      }
+
       return `calc(${widthPercentile}% - ${gap} * ${gapDistribution})`
     })
     .join(' ')
 }
 
-function validateColumnsProp({ columns }) {
+function validateColumnsProp(columns) {
   let columnsSum = 0
 
   // eslint-disable-next-line no-console

--- a/src/components/MaColumns/MaColumns.vue
+++ b/src/components/MaColumns/MaColumns.vue
@@ -39,10 +39,9 @@ export default {
   render(createElement, { parent, props, slots }) {
     const gap = getResponsiveGap({ parent, gap: props.gap })
     const columns = getResponsiveColumns({ parent, columns: props.columns })
-    const hasAutoFlow = checkAutoFlow({ columns })
     const style = { gap }
 
-    if (!hasAutoFlow) {
+    if (!hasAutoFlow({ columns })) {
       style.gridTemplateColumns = getGridTemplateColumns({ gap, columns })
       style.justifyContent = props.justify
     }
@@ -52,7 +51,7 @@ export default {
       {
         class: {
           grid: true,
-          hasAutoFlow,
+          'has-auto-flow': hasAutoFlow({ columns }),
           [`vertical-align-${props.verticalAlign}`]: true,
         },
         style,
@@ -74,7 +73,7 @@ function getResponsiveColumns({ parent, columns }) {
   return responsiveColumns
 }
 
-function checkAutoFlow({ columns }) {
+function hasAutoFlow({ columns }) {
   return columns.includes(autoFlowOperator)
 }
 
@@ -92,8 +91,10 @@ function getGridTemplateColumns({ gap, columns }) {
 
 function validateColumnsProp({ columns }) {
   let columnsSum = 0
+
   // eslint-disable-next-line no-console
   const logError = (message) => console.error(`[Layout Error] ${message}`)
+
   columns.forEach((c, i) => {
     if (c === '*') {
       if (columns.length !== 1) {
@@ -111,6 +112,7 @@ function validateColumnsProp({ columns }) {
     }
     columnsSum += columnValue
   })
+
   if (columnsSum > columnCount) {
     logError(`The row overflows the ${columnCount}-column layout.`)
   }
@@ -121,7 +123,7 @@ function validateColumnsProp({ columns }) {
 .grid {
   display: grid;
 }
-.hasAutoFlow {
+.has-auto-flow {
   grid-auto-flow: column;
 }
 .vertical-align-center {

--- a/src/components/MaColumns/MaColumns.vue
+++ b/src/components/MaColumns/MaColumns.vue
@@ -49,13 +49,15 @@ export default {
     /**
      * Defines how the space between and around content items is distributed. Defaults to start.
      *
-     * @values space-around, space-between, start, end
+     * @values space-around, space-between, start, end, center
      */
     justify: {
       type: String,
       default: 'start',
       validator: (value) =>
-        ['space-around', 'space-between', 'start', 'end'].includes(value),
+        ['space-around', 'space-between', 'start', 'end', 'center'].includes(
+          value
+        ),
     },
 
     /**

--- a/src/components/MaColumns/MaColumns.vue
+++ b/src/components/MaColumns/MaColumns.vue
@@ -1,15 +1,12 @@
 <script>
+/** @typedef {import('vue').VNodeData} VNodeData */
+import { mergeData } from 'vue-functional-data-merge'
 import { spacing } from '../../tokens'
 import { responsivePropValidator } from '@margarita/utils/responsivePropValidator'
 
 const columnCount = 12
 const autoFlowOperator = '*'
 
-/**
- * Renders a list of columns following the Design System guidelines
- *
- * [Component's API documentation](https://holaluz.github.io/margarita/?path=/story/layout-columns--columns)
- */
 export default {
   name: 'MaColumns',
 
@@ -80,7 +77,7 @@ export default {
     },
   },
 
-  render(createElement, { parent, props, slots }) {
+  render(createElement, { parent, props, slots, data }) {
     const gap = getResponsiveGap({ parent, gap: props.gap })
     const columns = getResponsiveColumns({ parent, columns: props.columns })
     const style = { gap }
@@ -90,18 +87,17 @@ export default {
       style.justifyContent = props.justify
     }
 
-    return createElement(
-      'div',
-      {
-        class: {
-          grid: true,
-          'has-auto-flow': hasAutoFlow({ columns }),
-          [`vertical-align-${props.verticalAlign}`]: true,
-        },
-        style,
+    /** @type {VNodeData} */
+    const componentData = {
+      staticClass: `grid`,
+      class: {
+        'has-auto-flow': hasAutoFlow({ columns }),
+        [`vertical-align-${props.verticalAlign}`]: true,
       },
-      slots().default
-    )
+      style,
+    }
+
+    return createElement('div', mergeData(data, componentData), slots().default)
   },
 }
 

--- a/src/components/MaColumns/MaColumns.vue
+++ b/src/components/MaColumns/MaColumns.vue
@@ -5,23 +5,55 @@ import { responsivePropValidator } from '@margarita/utils/responsivePropValidato
 const columnCount = 12
 const autoFlowOperator = '*'
 
+/**
+ * Renders a list of columns following the Design System guidelines
+ *
+ * [Component's API documentation](https://holaluz.github.io/margarita/?path=/story/layout-columns--columns)
+ */
 export default {
   name: 'MaColumns',
 
   functional: true,
 
   props: {
+    /**
+     * Defines the columns layout.
+     *
+     * ```ts
+     * <ma-column columns="12">...</ma-column>
+     * <ma-column :columns="['4', '4', '4']">...</ma-column>
+     * ```
+     */
     columns: {
       type: [Array, String],
       required: true,
     },
 
+    /**
+     * Sets the space gap between children.
+     *
+     * If an array is passed, values will target the design system breakpoints.
+     * ```ts
+     * // This would apply medium on all the different breakpoints
+     * space = 'small'
+     * // This would apply none on mobile, small on tablet and large on desktop
+     * :space="['none', 'small', 'large']"
+     * ```
+     *
+     * [Spacing tokens documentation](https://holaluz.github.io/margarita/?path=/story/tokens-spacing--page)
+     * @values none, xsmall, small, medium, large, xlarge, 2x-large, 3x-large, 4x-large, 5x-large, 6x-large
+     */
     gap: {
       type: [Array, String],
       required: true,
       validator: responsivePropValidator(Object.keys(spacing)),
     },
 
+    /**
+     * Defines how the space between and around content items is distributed. Defaults to start.
+     *
+     * @values space-around, space-between, start, end
+     */
     justify: {
       type: String,
       default: 'start',
@@ -29,6 +61,18 @@ export default {
         ['space-around', 'space-between', 'start', 'end'].includes(value),
     },
 
+    /**
+     * Sets the children vertical alignment. Defaults to fill.
+     *
+     * If an array is passed, values will target the design system breakpoints.
+     * ```ts
+     * // This would apply start on all the different breakpoints
+     * align = 'start'
+     * // This would apply fill on mobile, center on tablet and start on desktop
+     * :align="['fill', 'center', 'start']"
+     * ```
+     * @values start, center, fill, end
+     */
     verticalAlign: {
       type: String,
       default: 'fill',

--- a/src/components/MaColumns/MaColumns.vue
+++ b/src/components/MaColumns/MaColumns.vue
@@ -1,0 +1,136 @@
+<script>
+import { spacing } from '../../tokens'
+import { responsivePropValidator } from '@margarita/utils/responsivePropValidator'
+
+const columnCount = 12
+const autoFlowOperator = '*'
+
+export default {
+  name: 'MaColumns',
+
+  functional: true,
+
+  props: {
+    columns: {
+      type: [Array, String],
+      required: true,
+    },
+
+    gap: {
+      type: [Array, String],
+      required: true,
+      validator: responsivePropValidator(Object.keys(spacing)),
+    },
+
+    justify: {
+      type: String,
+      default: 'start',
+      validator: (value) =>
+        ['space-around', 'space-between', 'start', 'end'].includes(value),
+    },
+
+    verticalAlign: {
+      type: String,
+      default: 'fill',
+      validator: (value) => ['start', 'center', 'fill', 'end'].includes(value),
+    },
+  },
+
+  render(createElement, { parent, props, slots }) {
+    const gap = getResponsiveGap({ parent, gap: props.gap })
+    const columns = getResponsiveColumns({ parent, columns: props.columns })
+    const hasAutoFlow = checkAutoFlow({ columns })
+    const style = { gap }
+
+    if (!hasAutoFlow) {
+      style.gridTemplateColumns = getGridTemplateColumns({ gap, columns })
+      style.justifyContent = props.justify
+    }
+
+    return createElement(
+      'div',
+      {
+        class: {
+          grid: true,
+          hasAutoFlow,
+          [`vertical-align-${props.verticalAlign}`]: true,
+        },
+        style,
+      },
+      slots().default
+    )
+  },
+}
+
+function getResponsiveGap({ parent, gap }) {
+  return spacing[parent.$layout.getResponsivePropValue(gap)]
+}
+
+function getResponsiveColumns({ parent, columns }) {
+  const responsiveColumns = parent.$layout
+    .getResponsivePropValue(columns)
+    .split(' ')
+  validateColumnsProp({ columns: responsiveColumns })
+  return responsiveColumns
+}
+
+function checkAutoFlow({ columns }) {
+  return columns.includes(autoFlowOperator)
+}
+
+// Gets the size of each column without overflowing due to the gap
+// https://stackoverflow.com/a/45092180
+function getGridTemplateColumns({ gap, columns }) {
+  const gapDistribution = (columns.length - 1) / columns.length
+  return columns
+    .map((c) => {
+      const widthPercentile = (c / columnCount) * 100
+      return `calc(${widthPercentile}% - ${gap} * ${gapDistribution})`
+    })
+    .join(' ')
+}
+
+function validateColumnsProp({ columns }) {
+  let columnsSum = 0
+  // eslint-disable-next-line no-console
+  const logError = (message) => console.error(`[Layout Error] ${message}`)
+  columns.forEach((c, i) => {
+    if (c === '*') {
+      if (columns.length !== 1) {
+        logError(
+          'The autoFlow operator (*) cannot have other columns in the row.'
+        )
+      }
+      return
+    }
+    const columnValue = parseFloat(c)
+    if (isNaN(columnValue) || !Number.isInteger(columnValue)) {
+      logError(`Column #${i} must be an integer.`)
+    } else if (columnValue > columnCount || columnValue < 0) {
+      logError(`Column #${i} must have a value from 0 to ${columnCount}.`)
+    }
+    columnsSum += columnValue
+  })
+  if (columnsSum > columnCount) {
+    logError(`The row overflows the ${columnCount}-column layout.`)
+  }
+}
+</script>
+
+<style scoped>
+.grid {
+  display: grid;
+}
+.hasAutoFlow {
+  grid-auto-flow: column;
+}
+.vertical-align-center {
+  align-items: center;
+}
+.vertical-align-start {
+  align-items: flex-start;
+}
+.vertical-align-end {
+  align-items: flex-end;
+}
+</style>

--- a/src/components/MaColumns/index.js
+++ b/src/components/MaColumns/index.js
@@ -1,0 +1,3 @@
+import MaColumns from './MaColumns'
+
+export default MaColumns

--- a/src/components/MaLayout/MaLayout.spec.js
+++ b/src/components/MaLayout/MaLayout.spec.js
@@ -1,0 +1,41 @@
+/* eslint-disable no-console */
+import { render } from '@margarita/margarita-test-utils'
+import MaLayout from './MaLayout'
+
+describe('MaLayout', () => {
+  test('adds only one stack if no columns are provided', () => {
+    const { stacks, grids } = renderComponent({ columns: '' })
+
+    expect(stacks).toHaveLength(1)
+    expect(grids).toHaveLength(0)
+  })
+
+  test('adds one stack and one grid if columns are provided', () => {
+    const { stacks, grids } = renderComponent({ columns: '1' })
+
+    expect(stacks).toHaveLength(1)
+    expect(grids).toHaveLength(1)
+  })
+
+  test('adds one stack and two grids if two rows are provided', () => {
+    const { stacks, grids } = renderComponent({ columns: '1 - 1' })
+    expect(stacks).toHaveLength(1)
+    expect(grids).toHaveLength(2)
+  })
+})
+
+function renderComponent(props) {
+  const utils = render(MaLayout, {
+    props: { gap: 'small', columns: '12', space: 'small', ...props },
+    slots: { default: 'content' },
+  })
+
+  const stacks = utils.baseElement.querySelectorAll('.stack')
+  const grids = utils.baseElement.querySelectorAll('.grid')
+
+  return {
+    ...utils,
+    stacks,
+    grids,
+  }
+}

--- a/src/components/MaLayout/MaLayout.spec.js
+++ b/src/components/MaLayout/MaLayout.spec.js
@@ -22,12 +22,32 @@ describe('MaLayout', () => {
     expect(stacks).toHaveLength(1)
     expect(grids).toHaveLength(2)
   })
+
+  test('keeps additional attributes', () => {
+    const { getByTestId } = render({
+      components: { MaLayout },
+      template: `
+        <ma-layout data-testid="layout" gap="small" columns="12" id="123" :class="['class1', 'class2']">
+          <div data-testid="div" id="456" class="class"></div>
+        </ma-layout>
+      `,
+    })
+
+    const layout = getByTestId('layout')
+    expect(layout).toHaveAttribute('id', '123')
+    expect(layout).toHaveClass('stack', 'class1', 'class2')
+
+    const div = getByTestId('div')
+    expect(div).toHaveAttribute('id', '456')
+    expect(div).toHaveClass('class')
+  })
 })
 
-function renderComponent(props) {
+function renderComponent(props, attrs = {}) {
   const utils = render(MaLayout, {
     props: { gap: 'small', columns: '12', space: 'small', ...props },
     slots: { default: 'content' },
+    ...attrs,
   })
 
   const stacks = utils.baseElement.querySelectorAll('.stack')

--- a/src/components/MaLayout/MaLayout.stories.js
+++ b/src/components/MaLayout/MaLayout.stories.js
@@ -1,14 +1,15 @@
 import { spacing } from '@margarita/tokens'
-import MaColumns from './MaColumns'
-import docs from '../../../docs/components/MaColumns.docs.mdx'
+import DemoBlock from './examples/DemoBlock'
+import MaLayout from './MaLayout'
+import docs from '../../../docs/components/MaLayout.docs.mdx'
 
 export default {
-  title: 'Layout/Columns',
-  component: MaColumns,
+  title: 'Layout/Layout',
+  component: MaLayout,
   args: {
     gap: 'small',
     verticalAlign: 'start',
-    columns: ['12', '4 2 2 4', '3 2 4 3'],
+    columns: ['12', '12 - 4 2 2 4 - 3 2 4'],
   },
   argTypes: {
     gap: {
@@ -22,10 +23,16 @@ export default {
     verticalAlign: {
       control: {
         type: 'select',
-        options: ['space-around', 'space-between', 'start', 'end'],
+        options: ['fill', 'center', 'start', 'end'],
       },
       description:
         'If an array is passed, values will target the design system breakpoints',
+    },
+    justify: {
+      control: {
+        type: 'select',
+        options: ['space-around', 'space-between', 'start', 'end'],
+      },
     },
   },
   parameters: {
@@ -33,27 +40,20 @@ export default {
   },
 }
 
-const DemoBlock = {
-  template: `
-  <span style="width: 100%;background-color:#dcdcdc;text-align:center;color:#212121;padding:1rem 1rem;outline:1px solid #bbb">
-     <slot />
-  </span>
-  `,
-}
-
-const ColumnsTemplate = (args, { argTypes }) => ({
+const LayoutTemplate = (args, { argTypes }) => ({
   components: { DemoBlock },
   props: Object.keys(argTypes),
   template: `
   <ma-stack space="large">
     <ma-text>Columns: {{columns}}</ma-text>
+    <ma-text>Check <a href="/?path=/docs/layout-layout--layout">the docs</a> for more examples of the columns prop.</ma-text>
     <div style="background-color:#f1f1f1;width:400px">
-      <ma-columns v-bind="$props">
-        <demo-block v-for="i in 8" :key="i">{{ i }}</demo-block>
-      </ma-columns>
+      <ma-layout v-bind="$props">
+        <demo-block v-for="i in 8" :key="i" :height="i===5 ? '5rem' : 'auto'">{{ i }}</demo-block>
+      </ma-layout>
     </div>
   </ma-stack>
   `,
 })
 
-export const Columns = ColumnsTemplate.bind({})
+export const Layout = LayoutTemplate.bind({})

--- a/src/components/MaLayout/MaLayout.vue
+++ b/src/components/MaLayout/MaLayout.vue
@@ -93,6 +93,7 @@ export default {
         gap: props.gap,
         justify: props.justify,
         verticalAlign: props.verticalAlign,
+        data,
       })
     }
 
@@ -100,7 +101,7 @@ export default {
       createElement,
       dom,
       gap: props.gap,
-      staticClass: data.staticClass || '',
+      data,
     })
   },
 }
@@ -110,8 +111,8 @@ function getGrid({ parent, columns }) {
   return responsiveColumns.split(' - ').map((row) => row.split(' '))
 }
 
-function renderStack({ createElement, dom, gap, staticClass }) {
-  return createElement(MaStack, { staticClass, props: { space: gap } }, dom)
+function renderStack({ createElement, dom, gap, data }) {
+  return createElement(MaStack, { props: { space: gap }, ...data }, dom)
 }
 
 function renderGrid({ createElement, dom, grid, gap, justify, verticalAlign }) {

--- a/src/components/MaLayout/MaLayout.vue
+++ b/src/components/MaLayout/MaLayout.vue
@@ -36,8 +36,8 @@ export default {
   },
 
   render(createElement, { parent, props, slots, data }) {
-    const staticClass = data.staticClass || ''
     let dom = slots().default
+
     if (props.columns) {
       const grid = getGrid({ parent, columns: props.columns })
       dom = renderGrid({
@@ -49,11 +49,12 @@ export default {
         verticalAlign: props.verticalAlign,
       })
     }
+
     return renderStack({
       createElement,
       dom,
       gap: props.gap,
-      staticClass,
+      staticClass: data.staticClass || '',
     })
   },
 }
@@ -65,6 +66,30 @@ function getGrid({ parent, columns }) {
 
 function renderStack({ createElement, dom, gap, staticClass }) {
   return createElement(MaStack, { staticClass, props: { space: gap } }, dom)
+}
+
+function renderGrid({ createElement, dom, grid, gap, justify, verticalAlign }) {
+  let lastIdx = 0
+
+  return grid.map((row, i) => {
+    const isLast = i === grid.length - 1
+    const children = dom.filter((c) => c.tag)
+
+    const rowChildren = children.slice(
+      lastIdx,
+      isLast ? children.length : lastIdx + row.length
+    )
+    lastIdx += row.length
+
+    return renderColumns({
+      createElement,
+      columns: row.join(' '),
+      children: rowChildren,
+      gap,
+      justify,
+      verticalAlign,
+    })
+  })
 }
 
 function renderColumns({
@@ -87,26 +112,5 @@ function renderColumns({
     },
     children
   )
-}
-
-function renderGrid({ createElement, dom, grid, gap, justify, verticalAlign }) {
-  let lastIdx = 0
-  return grid.map((row, i) => {
-    const isLast = i === grid.length - 1
-    const children = dom.filter((c) => c.tag)
-    const rowChildren = children.slice(
-      lastIdx,
-      isLast ? children.length : lastIdx + row.length
-    )
-    lastIdx += row.length
-    return renderColumns({
-      createElement,
-      columns: row.join(' '),
-      children: rowChildren,
-      gap,
-      justify,
-      verticalAlign,
-    })
-  })
 }
 </script>

--- a/src/components/MaLayout/MaLayout.vue
+++ b/src/components/MaLayout/MaLayout.vue
@@ -4,23 +4,55 @@ import { spacing } from '../../tokens'
 import MaStack from '../MaStack'
 import MaColumns from '../MaColumns'
 
+/**
+ * Renders a complex layout made of rows and columns following the Design System guidelines
+ *
+ * [Component's API documentation](https://holaluz.github.io/margarita/?path=/story/layout-layout--layout)
+ */
 export default {
   name: 'MaLayout',
 
   functional: true,
 
   props: {
+    /**
+     * Defines the columns layout.
+     *
+     * ```ts
+     * <ma-column columns="12">...</ma-column>
+     * <ma-column :columns="['4', '4', '4']">...</ma-column>
+     * ```
+     */
     columns: {
       type: [Array, String],
       default: '',
     },
 
+    /**
+     * Sets the space gap between child rows and columns.
+     *
+     * If an array is passed, values will target the design system breakpoints.
+     * ```ts
+     * // This would apply medium on all the different breakpoints
+     * space = 'small'
+     * // This would apply none on mobile, small on tablet and large on desktop
+     * :space="['none', 'small', 'large']"
+     * ```
+     *
+     * [Spacing tokens documentation](https://holaluz.github.io/margarita/?path=/story/tokens-spacing--page)
+     * @values none, xsmall, small, medium, large, xlarge, 2x-large, 3x-large, 4x-large, 5x-large, 6x-large
+     */
     gap: {
       type: [Array, String],
       required: true,
       validator: responsivePropValidator(Object.keys(spacing)),
     },
 
+    /**
+     * Defines how the space between and around content items is distributed. Defaults to start.
+     *
+     * @values space-around, space-between, start, end
+     */
     justify: {
       type: String,
       default: 'start',
@@ -28,6 +60,18 @@ export default {
         ['space-around', 'space-between', 'start', 'end'].includes(value),
     },
 
+    /**
+     * Sets the children vertical alignment. Defaults to fill.
+     *
+     * If an array is passed, values will target the design system breakpoints.
+     * ```ts
+     * // This would apply start on all the different breakpoints
+     * align = 'start'
+     * // This would apply fill on mobile, center on tablet and start on desktop
+     * :align="['fill', 'center', 'start']"
+     * ```
+     * @values start, center, fill, end
+     */
     verticalAlign: {
       type: String,
       default: 'fill',

--- a/src/components/MaLayout/MaLayout.vue
+++ b/src/components/MaLayout/MaLayout.vue
@@ -53,13 +53,15 @@ export default {
     /**
      * Defines how the space between and around content items is distributed. Defaults to start.
      *
-     * @values space-around, space-between, start, end
+     * @values space-around, space-between, start, end, center
      */
     justify: {
       type: String,
       default: 'start',
       validator: (value) =>
-        ['space-around', 'space-between', 'start', 'end'].includes(value),
+        ['space-around', 'space-between', 'start', 'end', 'center'].includes(
+          value
+        ),
     },
 
     /**

--- a/src/components/MaLayout/MaLayout.vue
+++ b/src/components/MaLayout/MaLayout.vue
@@ -20,8 +20,8 @@ export default {
      *
      * If an array is passed, values will target the design system breakpoints.
      * ```ts
-     * // This renders a stack for mobile and 3 column layout for desktop
-     * columns="['12', '4 4 4]'
+     * <ma-layout columns="12">...</ma-layout>
+     * <ma-layout :columns="['4', '4', '4']">...</ma-layout>
      * ```
      * [Layout documentation](https://holaluz.github.io/margarita/?path=/docs/layout-layout--layout)
      */

--- a/src/components/MaLayout/MaLayout.vue
+++ b/src/components/MaLayout/MaLayout.vue
@@ -1,0 +1,112 @@
+<script>
+import { responsivePropValidator } from '@margarita/utils/responsivePropValidator'
+import { spacing } from '../../tokens'
+import MaStack from '../MaStack'
+import MaColumns from '../MaColumns'
+
+export default {
+  name: 'MaLayout',
+
+  functional: true,
+
+  props: {
+    columns: {
+      type: [Array, String],
+      default: '',
+    },
+
+    gap: {
+      type: [Array, String],
+      required: true,
+      validator: responsivePropValidator(Object.keys(spacing)),
+    },
+
+    justify: {
+      type: String,
+      default: 'start',
+      validator: (value) =>
+        ['space-around', 'space-between', 'start', 'end'].includes(value),
+    },
+
+    verticalAlign: {
+      type: String,
+      default: 'fill',
+      validator: (value) => ['start', 'center', 'fill', 'end'].includes(value),
+    },
+  },
+
+  render(createElement, { parent, props, slots, data }) {
+    const staticClass = data.staticClass || ''
+    let dom = slots().default
+    if (props.columns) {
+      const grid = getGrid({ parent, columns: props.columns })
+      dom = renderGrid({
+        createElement,
+        dom,
+        grid,
+        gap: props.gap,
+        justify: props.justify,
+        verticalAlign: props.verticalAlign,
+      })
+    }
+    return renderStack({
+      createElement,
+      dom,
+      gap: props.gap,
+      staticClass,
+    })
+  },
+}
+
+function getGrid({ parent, columns }) {
+  const responsiveColumns = parent.$layout.getResponsivePropValue(columns)
+  return responsiveColumns.split(' - ').map((row) => row.split(' '))
+}
+
+function renderStack({ createElement, dom, gap, staticClass }) {
+  return createElement(MaStack, { staticClass, props: { space: gap } }, dom)
+}
+
+function renderColumns({
+  createElement,
+  columns,
+  children,
+  gap,
+  justify,
+  verticalAlign,
+}) {
+  return createElement(
+    MaColumns,
+    {
+      props: {
+        gap,
+        columns,
+        justify,
+        verticalAlign,
+      },
+    },
+    children
+  )
+}
+
+function renderGrid({ createElement, dom, grid, gap, justify, verticalAlign }) {
+  let lastIdx = 0
+  return grid.map((row, i) => {
+    const isLast = i === grid.length - 1
+    const children = dom.filter((c) => c.tag)
+    const rowChildren = children.slice(
+      lastIdx,
+      isLast ? children.length : lastIdx + row.length
+    )
+    lastIdx += row.length
+    return renderColumns({
+      createElement,
+      columns: row.join(' '),
+      children: rowChildren,
+      gap,
+      justify,
+      verticalAlign,
+    })
+  })
+}
+</script>

--- a/src/components/MaLayout/MaLayout.vue
+++ b/src/components/MaLayout/MaLayout.vue
@@ -18,10 +18,12 @@ export default {
     /**
      * Defines the columns layout.
      *
+     * If an array is passed, values will target the design system breakpoints.
      * ```ts
-     * <ma-column columns="12">...</ma-column>
-     * <ma-column :columns="['4', '4', '4']">...</ma-column>
+     * // This renders a stack for mobile and 3 column layout for desktop
+     * columns="['12', '4 4 4]'
      * ```
+     * [Layout documentation](https://holaluz.github.io/margarita/?path=/docs/layout-layout--layout)
      */
     columns: {
       type: [Array, String],
@@ -34,9 +36,9 @@ export default {
      * If an array is passed, values will target the design system breakpoints.
      * ```ts
      * // This would apply medium on all the different breakpoints
-     * space = 'small'
+     * gap = 'small'
      * // This would apply none on mobile, small on tablet and large on desktop
-     * :space="['none', 'small', 'large']"
+     * :gap="['none', 'small', 'large']"
      * ```
      *
      * [Spacing tokens documentation](https://holaluz.github.io/margarita/?path=/story/tokens-spacing--page)

--- a/src/components/MaLayout/examples/DemoBlock.js
+++ b/src/components/MaLayout/examples/DemoBlock.js
@@ -4,13 +4,26 @@ export default {
       type: String,
       default: 'auto',
     },
+    isVerticallyAligned: {
+      type: Boolean,
+      default: false,
+    },
+    index: {
+      type: Number,
+      default: null,
+    },
+  },
+  computed: {
+    hasFixedHeight() {
+      return this.index === 5 && this.isVerticallyAligned
+    },
   },
   template: `
-  <span 
+  <span
     style="width: 100%;background-color:#dcdcdc;text-align:center;color:#212121;padding:1rem;outline:1px solid #bbb"
-    :style="{ height }"
+    :style="{ height: hasFixedHeight ? '6rem' : 'auto' }"
   >
-     <slot />
+    <slot />
   </span>
   `,
 }

--- a/src/components/MaLayout/examples/DemoBlock.js
+++ b/src/components/MaLayout/examples/DemoBlock.js
@@ -1,0 +1,16 @@
+export default {
+  props: {
+    height: {
+      type: String,
+      default: 'auto',
+    },
+  },
+  template: `
+  <span 
+    style="width: 100%;background-color:#dcdcdc;text-align:center;color:#212121;padding:1rem;outline:1px solid #bbb"
+    :style="{ height }"
+  >
+     <slot />
+  </span>
+  `,
+}

--- a/src/components/MaLayout/examples/examples.stories.js
+++ b/src/components/MaLayout/examples/examples.stories.js
@@ -1,0 +1,106 @@
+import DemoBlock from './DemoBlock'
+
+export default {
+  title: 'Layout/Layout/examples',
+}
+
+const LayoutTemplate = ({
+  childCount,
+  columns,
+  title,
+  justify = 'start',
+}) => () => ({
+  components: { DemoBlock },
+  template: `
+  <div>
+  <h3>${title} (columns='${columns}')</h3>
+  <div style='background-color: rgb(241, 241, 241); width: 400px;margin-bottom:2rem'>
+    <ma-layout gap="small" columns="${columns}" justify="${justify}">
+        <demo-block v-for="i in ${childCount}" :key="i">{{ i }}</demo-block>
+    </ma-layout>
+  </div>
+  <div>
+  `,
+})
+
+export const Example1 = LayoutTemplate({
+  title: 'Full width rows',
+  columns: '12',
+  childCount: 3,
+})
+
+export const Example2 = LayoutTemplate({
+  title: 'Simple column layout',
+  columns: '2 4 6',
+  childCount: 3,
+})
+
+export const Example3 = LayoutTemplate({
+  title: 'Simple grid',
+  columns: '4 4 4',
+  childCount: 6,
+})
+
+export const Example4 = LayoutTemplate({
+  title: 'A complex grid',
+  columns: '3 4 5 - 5 4 3 - 12',
+  childCount: 7,
+})
+
+export const Example5 = LayoutTemplate({
+  title: 'An indeterminate number of columns',
+  columns: '3 4 5 - *',
+  childCount: 8,
+})
+
+export const Example6 = LayoutTemplate({
+  title: 'The 12 column layout',
+  columns: '1 - 2 - 3 - 4 - 5 - 6 - 7 - 8 - 9 - 10 - 11 - 12',
+  childCount: 12,
+})
+
+export const Example7 = LayoutTemplate({
+  title: 'Justify center',
+  columns: '3 4 5 - 5 - 5 4 3',
+  justify: 'center',
+  childCount: 7,
+})
+
+export const Example8 = LayoutTemplate({
+  title: 'Justify end',
+  columns: '3 4 5 - 5 - 5 4 3',
+  justify: 'end',
+  childCount: 7,
+})
+
+export const Example9 = LayoutTemplate({
+  title: 'Justify space between',
+  columns: '3 4 5 - 5 5 - 5 4 3',
+  justify: 'space-between',
+  childCount: 8,
+})
+
+export const Example10 = LayoutTemplate({
+  title: 'Justify space around',
+  columns: '3 4 5 - 5 5 - 5 4 3',
+  justify: 'space-around',
+  childCount: 8,
+})
+
+export const Example11 = () => ({
+  components: { DemoBlock },
+  template: `
+  <div>
+  <h3>Nested MaLayout:</h3>
+  <div style='background-color: rgb(241, 241, 241); width: 400px;margin-bottom:2rem'>
+    <ma-layout gap="small" columns="3 4 5">
+        <demo-block v-for="i in 5" :key="i">{{ i }}</demo-block>
+        <ma-layout gap="small" columns="12">
+          <demo-block>a</demo-block>
+          <demo-block>b</demo-block>
+        </ma-layout>
+    </ma-layout>
+  </div>
+  <div>
+  `,
+})

--- a/src/components/MaLayout/examples/examples.stories.js
+++ b/src/components/MaLayout/examples/examples.stories.js
@@ -9,14 +9,24 @@ const LayoutTemplate = ({
   columns,
   title,
   justify = 'start',
+  verticalAlign = '',
 }) => () => ({
   components: { DemoBlock },
   template: `
   <div>
   <h3>${title} (columns='${columns}')</h3>
   <div style='background-color: rgb(241, 241, 241); width: 400px;margin-bottom:2rem'>
-    <ma-layout gap="small" columns="${columns}" justify="${justify}">
-        <demo-block v-for="i in ${childCount}" :key="i">{{ i }}</demo-block>
+    <ma-layout
+      gap="small"
+      columns="${columns}"
+      justify="${justify}"
+      vertical-align="${verticalAlign || 'fill'}"
+    >
+      <demo-block
+        v-for="i in ${childCount}"
+        :key="i"
+        :height="${verticalAlign ? "i===5 ? '6rem' : 'auto'" : 'auto'}"
+      >{{ i }}</demo-block>
     </ma-layout>
   </div>
   <div>
@@ -61,33 +71,61 @@ export const Example6 = LayoutTemplate({
 
 export const Example7 = LayoutTemplate({
   title: 'Justify center',
-  columns: '3 4 5 - 5 - 5 4 3',
+  columns: '4 4 4 - 6 - 4 4 4',
   justify: 'center',
   childCount: 7,
 })
 
 export const Example8 = LayoutTemplate({
   title: 'Justify end',
-  columns: '3 4 5 - 5 - 5 4 3',
+  columns: '4 4 4 - 6 - 4 4 4',
   justify: 'end',
   childCount: 7,
 })
 
 export const Example9 = LayoutTemplate({
   title: 'Justify space between',
-  columns: '3 4 5 - 5 5 - 5 4 3',
+  columns: '4 4 4 - 5 5 - 4 4 4',
   justify: 'space-between',
   childCount: 8,
 })
 
 export const Example10 = LayoutTemplate({
   title: 'Justify space around',
-  columns: '3 4 5 - 5 5 - 5 4 3',
+  columns: '4 4 4 - 5 5 - 4 4 4',
   justify: 'space-around',
   childCount: 8,
 })
 
-export const Example11 = () => ({
+export const Example11 = LayoutTemplate({
+  title: 'Vertical align fill',
+  columns: '4 4 4 - 4 4 4 - 4 4 4',
+  childCount: 9,
+  verticalAlign: 'fill',
+})
+
+export const Example12 = LayoutTemplate({
+  title: 'Vertical align start',
+  columns: '4 4 4 - 4 4 4 - 4 4 4',
+  childCount: 9,
+  verticalAlign: 'start',
+})
+
+export const Example13 = LayoutTemplate({
+  title: 'Vertical align end',
+  columns: '4 4 4 - 4 4 4 - 4 4 4',
+  childCount: 9,
+  verticalAlign: 'end',
+})
+
+export const Example14 = LayoutTemplate({
+  title: 'Vertical align center',
+  columns: '4 4 4 - 4 4 4 - 4 4 4',
+  childCount: 9,
+  verticalAlign: 'center',
+})
+
+export const Example15 = () => ({
   components: { DemoBlock },
   template: `
   <div>

--- a/src/components/MaLayout/examples/examples.stories.js
+++ b/src/components/MaLayout/examples/examples.stories.js
@@ -12,24 +12,34 @@ const LayoutTemplate = ({
   verticalAlign = '',
 }) => () => ({
   components: { DemoBlock },
+  data() {
+    return {
+      childCount,
+      columns,
+      title,
+      justify,
+      verticalAlign,
+    }
+  },
   template: `
   <div>
-  <h3>${title} (columns='${columns}')</h3>
-  <div style='background-color: rgb(241, 241, 241); width: 400px;margin-bottom:2rem'>
-    <ma-layout
-      gap="small"
-      columns="${columns}"
-      justify="${justify}"
-      vertical-align="${verticalAlign || 'fill'}"
-    >
-      <demo-block
-        v-for="i in ${childCount}"
-        :key="i"
-        :height="${verticalAlign ? "i===5 ? '6rem' : 'auto'" : 'auto'}"
-      >{{ i }}</demo-block>
-    </ma-layout>
+    <h3>${title} (columns='${columns}')</h3>
+    <div style='background-color: rgb(241, 241, 241); width: 400px;margin-bottom:2rem'>
+      <ma-layout
+        gap="small"
+        columns="${columns}"
+        justify="${justify}"
+        vertical-align="${verticalAlign || 'fill'}"
+      >
+        <demo-block
+          v-for="i in ${childCount}"
+          :key="i"
+          :index="i"
+          :is-vertically-aligned="!!verticalAlign"
+        >{{i}}</demo-block>
+      </ma-layout>
+    </div>
   </div>
-  <div>
   `,
 })
 
@@ -129,16 +139,16 @@ export const Example15 = () => ({
   components: { DemoBlock },
   template: `
   <div>
-  <h3>Nested MaLayout:</h3>
-  <div style='background-color: rgb(241, 241, 241); width: 400px;margin-bottom:2rem'>
-    <ma-layout gap="small" columns="3 4 5">
-        <demo-block v-for="i in 5" :key="i">{{ i }}</demo-block>
-        <ma-layout gap="small" columns="12">
-          <demo-block>a</demo-block>
-          <demo-block>b</demo-block>
-        </ma-layout>
-    </ma-layout>
+    <h3>Nested MaLayout:</h3>
+    <div style='background-color: rgb(241, 241, 241); width: 400px;margin-bottom:2rem'>
+      <ma-layout gap="small" columns="3 4 5">
+          <demo-block v-for="i in 5" :key="i">{{ i }}</demo-block>
+          <ma-layout gap="small" columns="12">
+            <demo-block>a</demo-block>
+            <demo-block>b</demo-block>
+          </ma-layout>
+      </ma-layout>
+    </div>
   </div>
-  <div>
   `,
 })

--- a/src/components/MaLayout/index.js
+++ b/src/components/MaLayout/index.js
@@ -1,0 +1,3 @@
+import MaLayout from './MaLayout'
+
+export default MaLayout

--- a/src/components/MaStack/MaStack.spec.js
+++ b/src/components/MaStack/MaStack.spec.js
@@ -18,19 +18,19 @@ describe('Stack', () => {
   test('adds alignment classes', () => {
     const { contentWrapper } = renderComponent({ align: 'right' })
 
-    expect(contentWrapper).toHaveClass('stack--align-right')
+    expect(contentWrapper).toHaveStyle({ justifyItems: 'flex-end' })
   })
 
   test(`alignment class defaults to 'fill'`, () => {
     const { contentWrapper } = renderComponent({ space: 'medium' })
 
-    expect(contentWrapper).toHaveClass('stack--align-fill')
+    expect(contentWrapper).toHaveStyle({ justifyItems: 'stretch' })
   })
 
   test('adds alignment classes from array', () => {
     const { contentWrapper } = renderComponent({ align: ['center', 'right'] })
 
-    expect(contentWrapper).toHaveClass('stack--align-center')
+    expect(contentWrapper).toHaveStyle({ justifyItems: 'center' })
   })
 })
 

--- a/src/components/MaStack/MaStack.spec.js
+++ b/src/components/MaStack/MaStack.spec.js
@@ -32,6 +32,23 @@ describe('Stack', () => {
 
     expect(contentWrapper).toHaveStyle({ justifyItems: 'center' })
   })
+
+  test('keeps additional attributes', () => {
+    const { getByText } = render({
+      components: { MaStack },
+      template: `
+      <ma-stack space="small" :class="['custom-class']" id="123" random-attr>
+        content
+      </ma-stack>
+      `,
+    })
+
+    const content = getByText('content')
+
+    expect(content).toHaveAttribute('id', '123')
+    expect(content).toHaveAttribute('random-attr')
+    expect(content).toHaveClass('custom-class', 'stack')
+  })
 })
 
 function renderComponent(props) {

--- a/src/components/MaStack/MaStack.stories.js
+++ b/src/components/MaStack/MaStack.stories.js
@@ -58,18 +58,26 @@ const NestedStackTemplate = (args, { argTypes }) => ({
   components: { DemoBlock },
   props: Object.keys(argTypes),
   template: `
-    <ma-stack space="2x-large" style="width: 400px;outline: 1px solid red;background-color:#f1f1f2;padding:1rem">
-      <ma-stack space="xlarge" align="center" style="outline: 1px solid red">
-        <span style="font-size: 2rem">Log In</span>
+    <div style="width: 400px;outline: 1px solid red;background-color:#f1f1f2;padding:1rem">
+      <ma-stack space="2x-large">
+        <div style="outline: 1px solid red">
+          <ma-stack space="xlarge" align="center">
+            <span style="font-size: 2rem">Log In</span>
+          </ma-stack>
+        </div>
+        <div style="outline: 1px solid red">
+          <ma-stack space="small">
+            <ma-text-field label="email" />
+            <ma-text-field label="password" />
+            <span>reset my password</span>
+            <ma-button>submit</ma-button>
+          </ma-stack>
+        </div>
+        <div style="outline: 1px solid red">
+          <ma-alert text="wrong password!" type="warning" />
+        </div>
       </ma-stack>
-      <ma-stack space="small" style="outline: 1px solid red">
-        <ma-text-field label="email" />
-        <ma-text-field label="password" />
-        <span>reset my password</span>
-        <ma-button>submit</ma-button>
-      </ma-stack>
-      <ma-alert text="wrong password!" type="warning" />
-    </ma-stack>
+    </div>
   `,
 })
 

--- a/src/components/MaStack/MaStack.vue
+++ b/src/components/MaStack/MaStack.vue
@@ -1,4 +1,6 @@
 <script>
+/** @typedef {import('vue').VNodeData} VNodeData */
+import { mergeData } from 'vue-functional-data-merge'
 import { responsivePropValidator } from '@margarita/utils/responsivePropValidator'
 import { spacing } from '../../tokens'
 
@@ -66,22 +68,16 @@ export default {
     const space = spacing[responsiveSpace]
     const align = alignment[responsiveAlign]
 
-    return createElement(
-      'div',
-      {
-        class: {
-          stack: true,
-          ...data.class,
-        },
-        style: {
-          gap: space,
-          justifyItems: align,
-          ...data.style,
-        },
-        ...data,
+    /** @type {VNodeData} */
+    const componentData = {
+      staticClass: 'stack',
+      style: {
+        gap: space,
+        justifyItems: align,
       },
-      slots().default
-    )
+    }
+
+    return createElement('div', mergeData(data, componentData), slots().default)
   },
 }
 </script>

--- a/src/components/MaStack/MaStack.vue
+++ b/src/components/MaStack/MaStack.vue
@@ -1,18 +1,13 @@
-<template>
-  <div
-    :style="styles"
-    :class="[`stack--align-${responsiveAlign}`]"
-    class="stack"
-  >
-    <!-- @slot Stack content slot -->
-    <slot />
-  </div>
-</template>
-
 <script>
 import { responsivePropValidator } from '@margarita/utils/responsivePropValidator'
 import { spacing } from '../../tokens'
-const alignment = ['left', 'center', 'right', 'fill']
+
+const alignment = {
+  fill: 'stretch',
+  left: 'flex-start',
+  center: 'center',
+  right: 'flex-end',
+}
 
 /**
  * Renders a stack component following the Design System guidelines
@@ -21,6 +16,8 @@ const alignment = ['left', 'center', 'right', 'fill']
  */
 export default {
   name: 'MaStack',
+
+  functional: true,
 
   props: {
     /**
@@ -58,22 +55,33 @@ export default {
     align: {
       type: [Array, String],
       default: 'fill',
-      validator: responsivePropValidator(alignment),
+      validator: responsivePropValidator(Object.keys(alignment)),
     },
   },
 
-  computed: {
-    responsiveSpace() {
-      return this.$layout.getResponsivePropValue(this.space)
-    },
+  render(createElement, { parent, props, slots, data }) {
+    const responsiveSpace = parent.$layout.getResponsivePropValue(props.space)
+    const responsiveAlign = parent.$layout.getResponsivePropValue(props.align)
 
-    responsiveAlign() {
-      return this.$layout.getResponsivePropValue(this.align)
-    },
+    const space = spacing[responsiveSpace]
+    const align = alignment[responsiveAlign]
 
-    styles() {
-      return { gap: spacing[this.responsiveSpace] }
-    },
+    return createElement(
+      'div',
+      {
+        class: {
+          stack: true,
+          ...data.class,
+        },
+        style: {
+          gap: space,
+          justifyItems: align,
+          ...data.style,
+        },
+        ...data,
+      },
+      slots().default
+    )
   },
 }
 </script>
@@ -82,21 +90,5 @@ export default {
 .stack {
   display: grid;
   grid-auto-flow: row;
-}
-
-.stack--align-fill {
-  justify-items: stretch;
-}
-
-.stack--align-left {
-  justify-items: flex-start;
-}
-
-.stack--align-center {
-  justify-items: center;
-}
-
-.stack--align-right {
-  justify-items: flex-end;
 }
 </style>

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,6 @@ import './css/index.css'
 import MaAlert from './components/MaAlert'
 import MaButton from './components/MaButton'
 import MaCard from './components/MaCard'
-import MaColumns from './components/MaColumns'
 import MaDatagrid from './components/MaDatagrid'
 import MaHidden from './components/MaHidden'
 import MaIcon from './components/MaIcon'
@@ -25,7 +24,6 @@ export {
   MaAlert,
   MaButton,
   MaCard,
-  MaColumns,
   MaDatagrid,
   MaHidden,
   MaIcon,
@@ -51,7 +49,6 @@ function install(Vue) {
   Vue.component('MaAlert', MaAlert)
   Vue.component('MaButton', MaButton)
   Vue.component('MaCard', MaCard)
-  Vue.component('MaColumns', MaColumns)
   Vue.component('MaDatagrid', MaDatagrid)
   Vue.component('MaHidden', MaHidden)
   Vue.component('MaIcon', MaIcon)

--- a/src/index.js
+++ b/src/index.js
@@ -3,9 +3,11 @@ import './css/index.css'
 import MaAlert from './components/MaAlert'
 import MaButton from './components/MaButton'
 import MaCard from './components/MaCard'
+import MaColumns from './components/MaColumns'
 import MaDatagrid from './components/MaDatagrid'
 import MaHidden from './components/MaHidden'
 import MaIcon from './components/MaIcon'
+import MaLayout from './components/MaLayout'
 import MaModal from './components/MaModal'
 import MaOption from './components/MaOption'
 import MaPagination from './components/MaPagination'
@@ -23,9 +25,11 @@ export {
   MaAlert,
   MaButton,
   MaCard,
+  MaColumns,
   MaDatagrid,
   MaHidden,
   MaIcon,
+  MaLayout,
   MaModal,
   MaOption,
   MaPagination,
@@ -47,9 +51,11 @@ function install(Vue) {
   Vue.component('MaAlert', MaAlert)
   Vue.component('MaButton', MaButton)
   Vue.component('MaCard', MaCard)
+  Vue.component('MaColumns', MaColumns)
   Vue.component('MaDatagrid', MaDatagrid)
   Vue.component('MaHidden', MaHidden)
   Vue.component('MaIcon', MaIcon)
+  Vue.component('MaLayout', MaLayout)
   Vue.component('MaModal', MaModal)
   Vue.component('MaOption', MaOption)
   Vue.component('MaPagination', MaPagination)

--- a/vetur/attributes.json
+++ b/vetur/attributes.json
@@ -49,17 +49,34 @@
     "description": "Sets card's top padding"
   },
   "ma-columns/columns": {
-    "type": "array|string"
+    "type": "array|string",
+    "description": "Defines the columns layout.\n\n```ts\n<ma-column columns=\"12\">...</ma-column>\n<ma-column :columns=\"['4', '4', '4']\">...</ma-column>\n```"
   },
   "ma-columns/gap": {
-    "type": "array|string"
+    "type": "array|string",
+    "description": "Sets the space gap between children.\n\nIf an array is passed, values will target the design system breakpoints.\n```ts\n// This would apply medium on all the different breakpoints\nspace = 'small'\n// This would apply none on mobile, small on tablet and large on desktop\n:space=\"['none', 'small', 'large']\"\n```\n\n[Spacing tokens documentation](https://holaluz.github.io/margarita/?path=/story/tokens-spacing--page)",
+    "options": [
+      "none",
+      "xsmall",
+      "small",
+      "medium",
+      "large",
+      "xlarge",
+      "2x-large",
+      "3x-large",
+      "4x-large",
+      "5x-large",
+      "6x-large"
+    ]
   },
   "ma-columns/justify": {
     "type": "string",
+    "description": "Defines how the space between and around content items is distributed. Defaults to start.",
     "options": ["space-around", "space-between", "start", "end"]
   },
   "ma-columns/verticalAlign": {
     "type": "string",
+    "description": "Sets the children vertical alignment. Defaults to fill.\n\nIf an array is passed, values will target the design system breakpoints.\n```ts\n// This would apply start on all the different breakpoints\nalign = 'start'\n// This would apply fill on mobile, center on tablet and start on desktop\n:align=\"['fill', 'center', 'start']\"\n```",
     "options": ["start", "center", "fill", "end"]
   },
   "ma-datagrid/rows": {
@@ -157,17 +174,34 @@
     "description": "Sets icon's title"
   },
   "ma-layout/columns": {
-    "type": "array|string"
+    "type": "array|string",
+    "description": "Defines the columns layout.\n\n```ts\n<ma-column columns=\"12\">...</ma-column>\n<ma-column :columns=\"['4', '4', '4']\">...</ma-column>\n```"
   },
   "ma-layout/gap": {
-    "type": "array|string"
+    "type": "array|string",
+    "description": "Sets the space gap between child rows and columns.\n\nIf an array is passed, values will target the design system breakpoints.\n```ts\n// This would apply medium on all the different breakpoints\nspace = 'small'\n// This would apply none on mobile, small on tablet and large on desktop\n:space=\"['none', 'small', 'large']\"\n```\n\n[Spacing tokens documentation](https://holaluz.github.io/margarita/?path=/story/tokens-spacing--page)",
+    "options": [
+      "none",
+      "xsmall",
+      "small",
+      "medium",
+      "large",
+      "xlarge",
+      "2x-large",
+      "3x-large",
+      "4x-large",
+      "5x-large",
+      "6x-large"
+    ]
   },
   "ma-layout/justify": {
     "type": "string",
+    "description": "Defines how the space between and around content items is distributed. Defaults to start.",
     "options": ["space-around", "space-between", "start", "end"]
   },
   "ma-layout/verticalAlign": {
     "type": "string",
+    "description": "Sets the children vertical alignment. Defaults to fill.\n\nIf an array is passed, values will target the design system breakpoints.\n```ts\n// This would apply start on all the different breakpoints\nalign = 'start'\n// This would apply fill on mobile, center on tablet and start on desktop\n:align=\"['fill', 'center', 'start']\"\n```",
     "options": ["start", "center", "fill", "end"]
   },
   "ma-modal/title": {

--- a/vetur/attributes.json
+++ b/vetur/attributes.json
@@ -175,11 +175,11 @@
   },
   "ma-layout/columns": {
     "type": "array|string",
-    "description": "Defines the columns layout.\n\n```ts\n<ma-column columns=\"12\">...</ma-column>\n<ma-column :columns=\"['4', '4', '4']\">...</ma-column>\n```"
+    "description": "Defines the columns layout.\n\nIf an array is passed, values will target the design system breakpoints.\n```ts\n// This renders a stack for mobile and 3 column layout for desktop\ncolumns=\"['12', '4 4 4]'\n```\n[Layout documentation](https://holaluz.github.io/margarita/?path=/docs/layout-layout--layout)"
   },
   "ma-layout/gap": {
     "type": "array|string",
-    "description": "Sets the space gap between child rows and columns.\n\nIf an array is passed, values will target the design system breakpoints.\n```ts\n// This would apply medium on all the different breakpoints\nspace = 'small'\n// This would apply none on mobile, small on tablet and large on desktop\n:space=\"['none', 'small', 'large']\"\n```\n\n[Spacing tokens documentation](https://holaluz.github.io/margarita/?path=/story/tokens-spacing--page)",
+    "description": "Sets the space gap between child rows and columns.\n\nIf an array is passed, values will target the design system breakpoints.\n```ts\n// This would apply medium on all the different breakpoints\ngap = 'small'\n// This would apply none on mobile, small on tablet and large on desktop\n:gap=\"['none', 'small', 'large']\"\n```\n\n[Spacing tokens documentation](https://holaluz.github.io/margarita/?path=/story/tokens-spacing--page)",
     "options": [
       "none",
       "xsmall",

--- a/vetur/attributes.json
+++ b/vetur/attributes.json
@@ -48,6 +48,20 @@
     "type": "boolean",
     "description": "Sets card's top padding"
   },
+  "ma-columns/columns": {
+    "type": "array|string"
+  },
+  "ma-columns/gap": {
+    "type": "array|string"
+  },
+  "ma-columns/justify": {
+    "type": "string",
+    "options": ["space-around", "space-between", "start", "end"]
+  },
+  "ma-columns/verticalAlign": {
+    "type": "string",
+    "options": ["start", "center", "fill", "end"]
+  },
   "ma-datagrid/rows": {
     "type": "array",
     "description": "Sets the datagrid rows"
@@ -141,6 +155,20 @@
   "ma-icon/title": {
     "type": "string",
     "description": "Sets icon's title"
+  },
+  "ma-layout/columns": {
+    "type": "array|string"
+  },
+  "ma-layout/gap": {
+    "type": "array|string"
+  },
+  "ma-layout/justify": {
+    "type": "string",
+    "options": ["space-around", "space-between", "start", "end"]
+  },
+  "ma-layout/verticalAlign": {
+    "type": "string",
+    "options": ["start", "center", "fill", "end"]
   },
   "ma-modal/title": {
     "type": "string",

--- a/vetur/attributes.json
+++ b/vetur/attributes.json
@@ -50,7 +50,7 @@
   },
   "ma-columns/columns": {
     "type": "array|string",
-    "description": "Defines the columns layout.\n\n```ts\n<ma-column columns=\"12\">...</ma-column>\n<ma-column :columns=\"['4', '4', '4']\">...</ma-column>\n```"
+    "description": "Defines the columns layout.\n\n```ts\n<ma-column columns=\"6 6\">...</ma-column>\n<ma-column :columns=\"['12', '4 4 4', '6 6']\">...</ma-column>\n```"
   },
   "ma-columns/gap": {
     "type": "array|string",

--- a/vetur/attributes.json
+++ b/vetur/attributes.json
@@ -175,7 +175,7 @@
   },
   "ma-layout/columns": {
     "type": "array|string",
-    "description": "Defines the columns layout.\n\nIf an array is passed, values will target the design system breakpoints.\n```ts\n// This renders a stack for mobile and 3 column layout for desktop\ncolumns=\"['12', '4 4 4]'\n```\n[Layout documentation](https://holaluz.github.io/margarita/?path=/docs/layout-layout--layout)"
+    "description": "Defines the columns layout.\n\nIf an array is passed, values will target the design system breakpoints.\n```ts\n<ma-layout columns=\"12\">...</ma-layout>\n<ma-layout :columns=\"['4', '4', '4']\">...</ma-layout>\n```\n[Layout documentation](https://holaluz.github.io/margarita/?path=/docs/layout-layout--layout)"
   },
   "ma-layout/gap": {
     "type": "array|string",

--- a/vetur/tags.json
+++ b/vetur/tags.json
@@ -11,6 +11,10 @@
     "attributes": ["color", "hasPaddingTop"],
     "description": "Renders a card component following the Design System guidelines\n\n[Component's API documentation](https://holaluz.github.io/margarita/?path=/story/components-card--card)"
   },
+  "ma-columns": {
+    "attributes": ["columns", "gap", "justify", "verticalAlign"],
+    "description": ""
+  },
   "ma-datagrid": {
     "attributes": ["rows", "columns", "isLoading", "noResultsText"],
     "description": "Renders a datagrid component following the Design System guidelines\n\n[Component's API documentation](https://holaluz.github.io/margarita/?path=/story/components-datagrid--datagrid)"
@@ -30,6 +34,10 @@
       "title"
     ],
     "description": "Renders an icon component following the Design System guidelines\n\n[Component's API documentation](https://holaluz.github.io/margarita/?path=/story/components-icon--icon)"
+  },
+  "ma-layout": {
+    "attributes": ["columns", "gap", "justify", "verticalAlign"],
+    "description": ""
   },
   "ma-modal": {
     "attributes": ["title", "width", "headerType"],

--- a/vetur/tags.json
+++ b/vetur/tags.json
@@ -13,7 +13,7 @@
   },
   "ma-columns": {
     "attributes": ["columns", "gap", "justify", "verticalAlign"],
-    "description": ""
+    "description": "Renders a list of columns following the Design System guidelines\n\n[Component's API documentation](https://holaluz.github.io/margarita/?path=/story/layout-columns--columns)"
   },
   "ma-datagrid": {
     "attributes": ["rows", "columns", "isLoading", "noResultsText"],
@@ -37,7 +37,7 @@
   },
   "ma-layout": {
     "attributes": ["columns", "gap", "justify", "verticalAlign"],
-    "description": ""
+    "description": "Renders a complex layout made of rows and columns following the Design System guidelines\n\n[Component's API documentation](https://holaluz.github.io/margarita/?path=/story/layout-layout--layout)"
   },
   "ma-modal": {
     "attributes": ["title", "width", "headerType"],

--- a/vetur/tags.json
+++ b/vetur/tags.json
@@ -13,7 +13,7 @@
   },
   "ma-columns": {
     "attributes": ["columns", "gap", "justify", "verticalAlign"],
-    "description": "Renders a list of columns following the Design System guidelines\n\n[Component's API documentation](https://holaluz.github.io/margarita/?path=/story/layout-columns--columns)"
+    "description": ""
   },
   "ma-datagrid": {
     "attributes": ["rows", "columns", "isLoading", "noResultsText"],


### PR DESCRIPTION
This PR closes #274 

- [x] Port MaColumns
- [x] Port MaLayout
- [x] Add missing tests for Layout
- [x] Add vetur autocompletion prop tags
- [x] Add docs with examples
- [x] Document code where needed
- [ ] Also: right now, Columns and Layout use `gap` as a prop name, while Stack uses `space`. 
- [x] Check functionalDataMerge


^ any help with missing steps will be greatly appreciated! And woud help people understand the components better…