### PR TITLE
fix: MaModal responsiveness, UX & styling issues

### DIFF
--- a/src/components/MaModal/MaModal.css
+++ b/src/components/MaModal/MaModal.css
@@ -37,6 +37,7 @@
 
 .modal-header--white {
   --modal-header-icon-color: var(--color-pink-base);
+  padding-bottom: 0;
 }
 
 .modal-header--gradient {

--- a/src/components/MaModal/MaModal.css
+++ b/src/components/MaModal/MaModal.css
@@ -30,7 +30,7 @@
 .modal-header {
   display: flex;
   justify-content: space-between;
-  align-items: flex-start;
+  align-items: center;
   padding: var(--spacing-medium);
   border-radius: 4px 4px 0 0;
 }
@@ -41,19 +41,15 @@
 
 .modal-header--gradient {
   --modal-header-icon-color: var(--color-white-base);
-
   background: linear-gradient(to right, var(--gradient-holaluz));
-  color: var(--color-white-base);
-}
 
-.modal-header--gradient .modal-title {
-  text-align: center;
+  & .modal-title {
+    text-align: center;
+  }
 }
 
 .modal-title {
   flex: 1;
-  font-weight: 800;
-  font-size: 1.5rem;
 }
 
 .icon-close {
@@ -62,6 +58,7 @@
   padding: 0.4rem;
   margin-left: var(--spacing-medium);
   color: var(--modal-header-icon-color);
+  align-self: flex-start;
 }
 
 .icon-close--pink {

--- a/src/components/MaModal/MaModal.css
+++ b/src/components/MaModal/MaModal.css
@@ -1,6 +1,14 @@
 .modal-wrapper {
-  position: relative;
-
+  position: fixed;
+  background-color: var(--shadow-dark);
+  bottom: 0;
+  right: 0;
+  top: 0;
+  left: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.5rem;
   /**
    * TODO: Normalize z-indexes values across HL. For instance, this one is set
    * to 101 to trump CMB's z-index of 100.
@@ -8,23 +16,12 @@
   z-index: 101;
 }
 
-.modal-overlay {
-  position: fixed;
-  background-color: var(--shadow-dark);
-  width: 100%;
-  height: 100%;
-  top: 0;
-  left: 0;
-}
-
 .modal {
-  position: fixed;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  width: 96vw; /* so that it doesn't reach end of viewport */
-
+  width: 100%;
+  max-height: 100%;
   border-radius: 4px;
+  display: flex;
+  flex-direction: column;
   box-shadow: 0 2px 8px var(--shadow-dark);
   background-color: var(--color-white-base);
   word-break: break-word;
@@ -55,14 +52,14 @@
 
 .modal-title {
   flex: 1;
-  font-weight: 700;
+  font-weight: 800;
   font-size: 1.5rem;
 }
 
 .icon-close {
   border-style: solid;
   border-width: 1px;
-  padding: 0.25rem;
+  padding: 0.4rem;
   margin-left: var(--spacing-medium);
   color: var(--modal-header-icon-color);
 }
@@ -88,13 +85,10 @@
 }
 
 .modal-content {
-  /* because fuck standards, that's why: https://github.com/w3c/csswg-drafts/issues/129 */
-  margin-bottom: var(--spacing-medium);
+  margin: var(--spacing-medium) 0;
   padding: 0 var(--spacing-medium);
-  overflow-y: auto;
-
-  /* so that it doesn't reach end of viewport */
-  max-height: 85vh;
+  flex: 1;
+  overflow: auto;
 }
 
 .modal--width-small {
@@ -110,26 +104,15 @@
 .modal-transition-leave-to,
 .modal-transition-enter {
   opacity: 0;
+  & .modal {
+    transform: translateY(-10%);
+  }
 }
 
 .modal-transition-leave-active,
 .modal-transition-enter-active {
   transition: opacity 0.3s ease;
-}
-
-.modal-transition-enter-active .modal {
-  animation: slideFromTop 0.4s ease-in-out;
-}
-
-.modal-transition-leave-active .modal {
-  animation: slideFromTop 0.4s ease-in-out reverse;
-}
-
-@keyframes slideFromTop {
-  from {
-    top: 47%;
-  }
-  to {
-    top: 50%;
+  & .modal {
+    transition: transform 0.4s ease-in-out;
   }
 }

--- a/src/components/MaModal/MaModal.vue
+++ b/src/components/MaModal/MaModal.vue
@@ -28,7 +28,13 @@
               class="modal-header"
               data-testid="modal-header"
             >
-              <span class="modal-title">{{ title }}</span>
+              <ma-heading
+                class="modal-title"
+                :tone="headerType === 'gradient' ? 'white' : 'gray-dark'"
+                size="xsmall"
+              >
+                {{ title }}
+              </ma-heading>
               <ma-button
                 category="no-background"
                 data-testid="close-button"
@@ -56,6 +62,7 @@
 import { Portal as MaModalPortal } from '@linusborg/vue-simple-portal/dist/index.umd'
 import MaIcon from '@margarita/components/MaIcon'
 import MaButton from '@margarita/components/MaButton'
+import MaHeading from '@margarita/components/MaHeading'
 
 const FOCUSABLE_ELEMENTS = [
   'button',
@@ -81,6 +88,7 @@ export default {
     MaModalPortal,
     MaIcon,
     MaButton,
+    MaHeading,
   },
 
   props: {

--- a/src/components/MaModal/MaModal.vue
+++ b/src/components/MaModal/MaModal.vue
@@ -9,17 +9,16 @@
     </div>
     <ma-modal-portal>
       <transition name="modal-transition" @after-leave="closeModal">
-        <div v-if="showModal" class="modal-wrapper">
+        <div
+          v-if="showModal"
+          class="modal-wrapper"
+          data-testid="overlay"
+          @click.self="closeModal"
+        >
           <div
-            class="modal-overlay"
-            data-testid="overlay"
-            @click="closeModal"
-          />
-          <ma-stack
             ref="modal"
             :aria-label="title"
             :class="`modal--width-${width}`"
-            space="medium"
             role="dialog"
             aria-modal="true"
             class="modal"
@@ -46,7 +45,7 @@
                 -->
               <slot :closeModal="closeModal" name="content" />
             </div>
-          </ma-stack>
+          </div>
         </div>
       </transition>
     </ma-modal-portal>
@@ -55,7 +54,6 @@
 
 <script>
 import { Portal as MaModalPortal } from '@linusborg/vue-simple-portal/dist/index.umd'
-import MaStack from '@margarita/components/MaStack'
 import MaIcon from '@margarita/components/MaIcon'
 import MaButton from '@margarita/components/MaButton'
 
@@ -80,7 +78,6 @@ export default {
   name: 'MaModal',
 
   components: {
-    MaStack,
     MaModalPortal,
     MaIcon,
     MaButton,
@@ -206,7 +203,7 @@ export default {
       // If we cannot find the modal let's fail gracefully.
       if (!modal) return
 
-      this.focusableElements = modal.$el.querySelectorAll(FOCUSABLE_ELEMENTS)
+      this.focusableElements = modal.querySelectorAll(FOCUSABLE_ELEMENTS)
     },
 
     handleTabKey(e) {

--- a/src/components/MaModal/MaModal.vue
+++ b/src/components/MaModal/MaModal.vue
@@ -155,6 +155,7 @@ export default {
        */
       this.$emit('open')
 
+      document.body.style.overflowY = 'hidden'
       await this.setFocusWithin('modal-content')
       await this.setFocusableElements()
     },
@@ -178,6 +179,7 @@ export default {
        */
       this.$emit('close')
 
+      document.body.style.overflowY = ''
       await this.setFocusWithin('modal-trigger')
     },
 

--- a/src/components/MaModal/MaModal.vue
+++ b/src/components/MaModal/MaModal.vue
@@ -77,6 +77,8 @@ const FOCUSABLE_ELEMENTS = [
 const TAB_KEY = 9
 const ESCAPE_KEY = 27
 
+const OVERFLOW_HIDDEN_CLASS = 'overflow-y-hidden'
+
 /**
  * Renders a modal component following the Design System guidelines
  *
@@ -156,7 +158,7 @@ export default {
        */
       this.$emit('open')
 
-      document.body.style.overflowY = 'hidden'
+      document.body.classList.add(OVERFLOW_HIDDEN_CLASS)
       await this.setFocusWithin('modal-content')
       await this.setFocusableElements()
     },
@@ -180,7 +182,7 @@ export default {
        */
       this.$emit('close')
 
-      document.body.style.overflowY = ''
+      document.body.classList.remove(OVERFLOW_HIDDEN_CLASS)
       await this.setFocusWithin('modal-trigger')
     },
 
@@ -244,5 +246,12 @@ export default {
   },
 }
 </script>
+
+<style>
+/* unscoped style to affect <body> */
+.overflow-y-hidden {
+  overflow-y: hidden;
+}
+</style>
 
 <style src="./MaModal.css" scoped></style>

--- a/src/components/MaModal/MaModal.vue
+++ b/src/components/MaModal/MaModal.vue
@@ -36,6 +36,7 @@
                 {{ title }}
               </ma-heading>
               <ma-button
+                ref="closeButton"
                 category="no-background"
                 data-testid="close-button"
                 class="icon-close"
@@ -198,6 +199,8 @@ export default {
 
       if (firstFocusableElement) {
         firstFocusableElement.focus()
+      } else if (this.$refs.closeButton) {
+        this.$refs.closeButton.$el.focus()
       }
     },
 


### PR DESCRIPTION
- Fixes https://github.com/holaluz/margarita/issues/366
- Fixes https://github.com/holaluz/margarita/issues/357
- Uses MaHeading for the Heading.
- Fixes focus trap bug when there are no focusable elements inside ModalContent.
- The modal header white has now less padding because it was a bit ugly.\
- Modifies the close icon a bit so it looks more like the one in figma