### PR TITLE
fix: Fix MaOption vertical alignment

### DIFF
--- a/src/components/MaOption/MaOption.vue
+++ b/src/components/MaOption/MaOption.vue
@@ -10,9 +10,9 @@
       v-bind="$attrs"
     />
     <span class="indicator" />
-    <span class="description">
+    <ma-text size="small" class="description">
       <slot />
-    </span>
+    </ma-text>
   </label>
 </template>
 

--- a/src/components/MaOption/MaOptionCheckbox.css
+++ b/src/components/MaOption/MaOptionCheckbox.css
@@ -4,7 +4,7 @@
 
 .ma-option--checkbox .indicator {
   position: absolute;
-  top: 2px;
+  top: 0;
   left: 0;
   transition: border 0.4s, background-color 0.33s;
   border: 1px solid var(--color-gray-light);
@@ -16,8 +16,7 @@
 .ma-option--checkbox .description {
   /* .indicator is absolute-positioned. We need to make room for the text */
   padding-left: calc(var(--indicator-size) + 0.5rem);
-
-  line-height: 1.3;
+  margin-top: 2px;
   color: var(--color-gray-dark);
 }
 

--- a/src/components/MaOption/MaOptionRadio.css
+++ b/src/components/MaOption/MaOptionRadio.css
@@ -5,7 +5,7 @@
 .ma-option--radio .indicator {
   position: relative;
   flex-shrink: 0;
-  top: 4px;
+  top: 0;
   border: 1px solid var(--color-gray-base);
   border-radius: 50%;
   background-color: var(--color-white-base);
@@ -16,6 +16,7 @@
 }
 
 .ma-option--radio .description {
+  margin-top: 2px;
   padding-left: 0.5rem;
 }
 


### PR DESCRIPTION
Closes #346 

After gathering a bit of info, I do believe that having a property that allows the `MaOption` to be 'small' does not have lot of sense, because looking at the Design System, we only have **one approach** of the Checkbox and Radio input elements.

[Radio styles in the DS](https://www.figma.com/file/7RhweKibaUnxX6WYBl7zKW/Design-System-Beta?node-id=3540%3A6520)
[Checkbox styles in the DS](https://www.figma.com/file/7RhweKibaUnxX6WYBl7zKW/Design-System-Beta?node-id=3540%3A6348)

This being said, it kinda makes sense to just one approach, the one that we have in our DS (which basically means that the text we use as description should be `small` sized)

Checkbox:
![Screen Shot 2021-03-16 at 08 11 04](https://user-images.githubusercontent.com/25011566/111269987-9406f180-862f-11eb-9980-e6283aeda68e.png)

Radio:
![Screen Shot 2021-03-16 at 08 11 11](https://user-images.githubusercontent.com/25011566/111270101-b731a100-862f-11eb-8fd6-5febf80bbb6e.png)

Example with a multi-line checkbox:
![Screen Shot 2021-03-16 at 08 18 58](https://user-images.githubusercontent.com/25011566/111270568-522a7b00-8630-11eb-8a35-0a4d861ce9e0.png)
