### PR TITLE
fix: scoped styles in layout

### DIFF
--- a/src/components/MaColumns/MaColumns.vue
+++ b/src/components/MaColumns/MaColumns.vue
@@ -91,7 +91,7 @@ export default {
 
     /** @type {VNodeData} */
     const componentData = {
-      staticClass: `grid`,
+      staticClass: 'ma-grid',
       class: {
         'has-auto-flow': hasAutoFlow({ columns }),
         [`vertical-align-${props.verticalAlign}`]: true,
@@ -168,20 +168,20 @@ function validateColumnsProp(columns) {
 }
 </script>
 
-<style scoped>
-.grid {
+<style lang="postcss">
+.ma-grid {
   display: grid;
-}
-.has-auto-flow {
-  grid-auto-flow: column;
-}
-.vertical-align-center {
-  align-items: center;
-}
-.vertical-align-start {
-  align-items: flex-start;
-}
-.vertical-align-end {
-  align-items: flex-end;
+  &.has-auto-flow {
+    grid-auto-flow: column;
+  }
+  &.vertical-align-center {
+    align-items: center;
+  }
+  &.vertical-align-start {
+    align-items: flex-start;
+  }
+  &.vertical-align-end {
+    align-items: flex-end;
+  }
 }
 </style>

--- a/src/components/MaColumns/MaColumns.vue
+++ b/src/components/MaColumns/MaColumns.vue
@@ -91,7 +91,7 @@ export default {
 
     /** @type {VNodeData} */
     const componentData = {
-      staticClass: 'ma-grid',
+      staticClass: 'ma-columns',
       class: {
         'has-auto-flow': hasAutoFlow({ columns }),
         [`vertical-align-${props.verticalAlign}`]: true,
@@ -169,7 +169,7 @@ function validateColumnsProp(columns) {
 </script>
 
 <style lang="postcss">
-.ma-grid {
+.ma-columns {
   display: grid;
   &.has-auto-flow {
     grid-auto-flow: column;

--- a/src/components/MaLayout/MaLayout.spec.js
+++ b/src/components/MaLayout/MaLayout.spec.js
@@ -35,7 +35,7 @@ describe('MaLayout', () => {
 
     const layout = getByTestId('layout')
     expect(layout).toHaveAttribute('id', '123')
-    expect(layout).toHaveClass('stack', 'class1', 'class2')
+    expect(layout).toHaveClass('ma-stack', 'class1', 'class2')
 
     const div = getByTestId('div')
     expect(div).toHaveAttribute('id', '456')
@@ -50,8 +50,8 @@ function renderComponent(props, attrs = {}) {
     ...attrs,
   })
 
-  const stacks = utils.baseElement.querySelectorAll('.stack')
-  const grids = utils.baseElement.querySelectorAll('.grid')
+  const stacks = utils.baseElement.querySelectorAll('.ma-stack')
+  const grids = utils.baseElement.querySelectorAll('.ma-grid')
 
   return {
     ...utils,

--- a/src/components/MaLayout/MaLayout.spec.js
+++ b/src/components/MaLayout/MaLayout.spec.js
@@ -51,7 +51,7 @@ function renderComponent(props, attrs = {}) {
   })
 
   const stacks = utils.baseElement.querySelectorAll('.ma-stack')
-  const grids = utils.baseElement.querySelectorAll('.ma-grid')
+  const grids = utils.baseElement.querySelectorAll('.ma-columns')
 
   return {
     ...utils,

--- a/src/components/MaStack/MaStack.spec.js
+++ b/src/components/MaStack/MaStack.spec.js
@@ -47,7 +47,7 @@ describe('Stack', () => {
 
     expect(content).toHaveAttribute('id', '123')
     expect(content).toHaveAttribute('random-attr')
-    expect(content).toHaveClass('custom-class', 'stack')
+    expect(content).toHaveClass('custom-class', 'ma-stack')
   })
 })
 

--- a/src/components/MaStack/MaStack.vue
+++ b/src/components/MaStack/MaStack.vue
@@ -70,7 +70,7 @@ export default {
 
     /** @type {VNodeData} */
     const componentData = {
-      staticClass: 'stack',
+      staticClass: 'ma-stack',
       style: {
         gap: space,
         justifyItems: align,
@@ -82,8 +82,8 @@ export default {
 }
 </script>
 
-<style scoped>
-.stack {
+<style>
+.ma-stack {
   display: grid;
   grid-auto-flow: row;
 }


### PR DESCRIPTION
This fixes a bug where, by setting a class with scoped styles to a layout component, the css doesn't work.

This happened because if we have a scoped css in the parent component and also in the functional component, the data attribute of the HTML element gets overwritten by the css in the functional component.

Because of this, all parent scoped css stops working.

The solution? Stop using scoped css in functional components.