### PR TITLE
fix: Make MaTextField fluid

### DIFF
--- a/src/components/MaTextField/MaTextField.css
+++ b/src/components/MaTextField/MaTextField.css
@@ -45,7 +45,7 @@
   flex: 0 1 100%;
   transition: border 0.2s ease;
   padding: 0 0.5rem;
-  max-width: 100%;
+  width: 100%;
   height: 100%;
   font-size: 1rem;
   border: none;


### PR DESCRIPTION
Closes #382 

From:

![Captura de Pantalla 2021-03-24 a les 16 04 44](https://user-images.githubusercontent.com/9197791/112334715-eabd9c80-8cbb-11eb-9dd3-ef4197847e07.png)

To:

![Captura de Pantalla 2021-03-24 a les 16 04 35](https://user-images.githubusercontent.com/9197791/112334739-ef825080-8cbb-11eb-9e3b-b76995de164b.png)




---

Now, this could be seen as a breaking change because some layouts might change. I'd say, though, that the expectation is that MaTextField would take all available space, so not having this behavior was a bug.

Thoughts?