### PR TITLE
fix: Remove padding from MaOption

### DIFF
--- a/src/components/MaOption/MaOptionRadio.css
+++ b/src/components/MaOption/MaOptionRadio.css
@@ -1,7 +1,3 @@
-.ma-option--radio {
-  padding: 0.75rem 0;
-}
-
 .ma-option--radio .indicator {
   position: relative;
   flex-shrink: 0;


### PR DESCRIPTION
UI components should not interfere with external positioning/laying out – it is on Layout components to handle it.

This PR removes the additional padding surrounding every `MaOption`, which breaks the DS-based designs when using them.

Bear in mind that this might change some layouts.