### PR TITLE
fix: make ma-text & ma-heading functional

### DIFF
--- a/src/components/MaHeading/MaHeading.stories.js
+++ b/src/components/MaHeading/MaHeading.stories.js
@@ -1,4 +1,5 @@
 import MaHeading from '../MaHeading'
+import { tones } from '@margarita/tokens'
 
 export default {
   title: 'Components/Heading',
@@ -14,6 +15,12 @@ export default {
       control: {
         type: 'select',
         options: ['xsmall', 'small', 'medium', 'large', 'xlarge'],
+      },
+    },
+    tone: {
+      control: {
+        type: 'select',
+        options: Object.keys(tones),
       },
     },
   },

--- a/src/components/MaHeading/MaHeading.vue
+++ b/src/components/MaHeading/MaHeading.vue
@@ -1,11 +1,6 @@
-<template>
-  <component :is="headingTag" :style="computedStyle" class="ma-heading">
-    <slot />
-  </component>
-</template>
-
 <script>
 import { headings, tones } from '../../tokens'
+import { mergeData } from 'vue-functional-data-merge'
 const { headingSize } = headings
 /**
  * Renders heading following the Design System guidelines
@@ -14,6 +9,7 @@ const { headingSize } = headings
  */
 export default {
   name: 'MaHeading',
+  functional: true,
 
   props: {
     /**
@@ -46,29 +42,23 @@ export default {
     },
   },
 
-  computed: {
-    headingTag() {
-      return this.level === 'none' ? 'div' : `h${this.level}`
-    },
-
-    responsiveHeadingSize() {
-      return this.$layout.getResponsivePropValue(this.size)
-    },
-
-    computedStyle() {
-      const sizeStyles =
-        headingSize[this.$layout.currentBreakpoint][this.responsiveHeadingSize]
-
-      return {
-        'font-size': sizeStyles['font-size'],
-        'line-height': sizeStyles['line-height'],
+  render(createElement, { parent, props, slots, data }) {
+    const tag = props.level === 'none' ? 'div' : `h${props.level}`
+    const size = parent.$layout.getResponsivePropValue(props.size)
+    const sizeStyles = headingSize[parent.$layout.currentBreakpoint][size]
+    const componentData = {
+      staticClass: 'ma-heading',
+      style: {
+        fontSize: sizeStyles['font-size'],
+        lineHeight: sizeStyles['line-height'],
         '--top-crop': sizeStyles['top-crop'],
         '--bottom-crop': sizeStyles['bottom-crop'],
-        color: tones[this.tone],
-      }
-    },
+        color: tones[props.tone],
+      },
+    }
+    return createElement(tag, mergeData(data, componentData), slots().default)
   },
 }
 </script>
 
-<style scoped src="./MaHeading.css"></style>
+<style src="./MaHeading.css"></style>

--- a/src/components/MaText/MaText.css
+++ b/src/components/MaText/MaText.css
@@ -18,12 +18,12 @@
   &::after {
     margin-top: var(--bottom-crop);
   }
-}
 
-.ma-text--italic {
-  font-style: italic;
-}
+  &.ma-text--italic {
+    font-style: italic;
+  }
 
-.ma-text--bold {
-  font-weight: bold;
+  &.ma-text--bold {
+    font-weight: bold;
+  }
 }

--- a/src/components/MaText/MaText.vue
+++ b/src/components/MaText/MaText.vue
@@ -1,17 +1,7 @@
-<template>
-  <component
-    :is="tag"
-    :style="computedStyle"
-    :class="computedClass"
-    class="ma-text"
-  >
-    <!-- @slot Text content slot -->
-    <slot />
-  </component>
-</template>
-
 <script>
 import { text, tones } from '../../tokens'
+import { mergeData } from 'vue-functional-data-merge'
+
 /**
  * Renders text following the Design System guidelines
  *
@@ -19,6 +9,7 @@ import { text, tones } from '../../tokens'
  */
 export default {
   name: 'MaText',
+  functional: true,
 
   props: {
     /**
@@ -74,33 +65,31 @@ export default {
     },
   },
 
-  computed: {
-    responsiveTextSize() {
-      return this.$layout.getResponsivePropValue(this.size)
-    },
-
-    computedClass() {
-      return {
-        'ma-text--italic': this.italic,
-        'ma-text--bold': this.bold,
-      }
-    },
-
-    computedStyle() {
-      const sizeStyles =
-        text.textSize[this.$layout.currentBreakpoint][this.responsiveTextSize]
-
-      return {
-        'font-size': sizeStyles['font-size'],
-        'line-height': sizeStyles['line-height'],
+  render(createElement, { parent, props, slots, data }) {
+    const textSize = parent.$layout.getResponsivePropValue(props.size)
+    const sizeStyles = text.textSize[parent.$layout.currentBreakpoint][textSize]
+    const componentData = {
+      staticClass: 'ma-text',
+      class: {
+        'ma-text--bold': props.bold,
+        'ma-text--italic': props.italic,
+      },
+      style: {
+        fontSize: sizeStyles['font-size'],
+        lineHeight: sizeStyles['line-height'],
         '--top-crop': sizeStyles['top-crop'],
         '--bottom-crop': sizeStyles['bottom-crop'],
-        'text-align': this.align,
-        color: tones[this.tone],
-      }
-    },
+        textAlign: props.align,
+        color: tones[props.tone],
+      },
+    }
+    return createElement(
+      props.tag,
+      mergeData(data, componentData),
+      slots().default
+    )
   },
 }
 </script>
 
-<style scoped src="./MaText.css"></style>
+<style src="./MaText.css"></style>

--- a/src/components/MaText/MaText.vue
+++ b/src/components/MaText/MaText.vue
@@ -66,8 +66,8 @@ export default {
   },
 
   render(createElement, { parent, props, slots, data }) {
-    const textSize = parent.$layout.getResponsivePropValue(props.size)
-    const sizeStyles = text.textSize[parent.$layout.currentBreakpoint][textSize]
+    const size = parent.$layout.getResponsivePropValue(props.size)
+    const sizeStyles = text.textSize[parent.$layout.currentBreakpoint][size]
     const componentData = {
       staticClass: 'ma-text',
       class: {


### PR DESCRIPTION
Fixes https://github.com/holaluz/margarita/issues/372 (I think). I have tried it with `npm link` and everything seems to work in `dry-martini`, but I honestly don't know why.

I made the components functional and removed their scoped css so that the attribute for the scoped css doesn't get overwritten like it happened with ma-layout -> https://github.com/holaluz/margarita/pull/376 .