### PR TITLE
chore: do not load legacy fonts

### DIFF
--- a/src/css/partials/ciutadella.css
+++ b/src/css/partials/ciutadella.css
@@ -2,80 +2,50 @@
   font-family: Ciutadella;
   font-weight: 400;
   font-display: swap;
-  src: url(https://assets.holaluz.com/fonts/ciutadella/Ci1001-Rg.eot)
-      format('eot'),
-    url(https://assets.holaluz.com/fonts/ciutadella/Ci1001-Rg.woff2)
+  src: url(https://assets.holaluz.com/fonts/ciutadella/Ci1001-Rg.woff2)
       format('woff2'),
     url(https://assets.holaluz.com/fonts/ciutadella/Ci1001-Rg.woff)
-      format('woff'),
-    url(https://assets.holaluz.com/fonts/ciutadella/Ci1001-Rg.ttf)
-      format('truetype'),
-    url('https://assets.holaluz.com/fonts/ciutadella/Ci1001-Rg.svg#str-replace(%22Ciutadella%22,%20%22%20%22,%20%22_%22)')
-      format('svg');
+      format('woff');
 }
 
 @font-face {
   font-family: Ciutadella;
   font-weight: 900;
   font-display: swap;
-  src: url(https://assets.holaluz.com/fonts/ciutadella/Ci1001-Bd.eot)
-      format('eot'),
-    url(https://assets.holaluz.com/fonts/ciutadella/Ci1001-Bd.woff2)
+  src: url(https://assets.holaluz.com/fonts/ciutadella/Ci1001-Bd.woff2)
       format('woff2'),
     url(https://assets.holaluz.com/fonts/ciutadella/Ci1001-Bd.woff)
-      format('woff'),
-    url(https://assets.holaluz.com/fonts/ciutadella/Ci1001-Bd.ttf)
-      format('truetype'),
-    url('https://assets.holaluz.com/fonts/ciutadella/Ci1001-Bd.svg#str-replace(%22Ciutadella%22,%20%22%20%22,%20%22_%22)')
-      format('svg');
+      format('woff');
 }
 
 @font-face {
   font-family: Ciutadella;
   font-weight: 500;
   font-display: swap;
-  src: url(https://assets.holaluz.com/fonts/ciutadella/Ci1001-Md.eot)
-      format('eot'),
-    url(https://assets.holaluz.com/fonts/ciutadella/Ci1001-Md.woff2)
+  src: url(https://assets.holaluz.com/fonts/ciutadella/Ci1001-Md.woff2)
       format('woff2'),
     url(https://assets.holaluz.com/fonts/ciutadella/Ci1001-Md.woff)
-      format('woff'),
-    url(https://assets.holaluz.com/fonts/ciutadella/Ci1001-Md.ttf)
-      format('truetype'),
-    url('https://assets.holaluz.com/fonts/ciutadella/Ci1001-Md.svg#str-replace(%22Ciutadella%22,%20%22%20%22,%20%22_%22)')
-      format('svg');
+      format('woff');
 }
 
 @font-face {
   font-family: Ciutadella;
   font-weight: 700;
   font-display: swap;
-  src: url(https://assets.holaluz.com/fonts/ciutadella/Ci1001-SmBd.eot)
-      format('eot'),
-    url(https://assets.holaluz.com/fonts/ciutadella/Ci1001-SmBd.woff2)
+  src: url(https://assets.holaluz.com/fonts/ciutadella/Ci1001-SmBd.woff2)
       format('woff2'),
     url(https://assets.holaluz.com/fonts/ciutadella/Ci1001-SmBd.woff)
-      format('woff'),
-    url(https://assets.holaluz.com/fonts/ciutadella/Ci1001-SmBd.ttf)
-      format('truetype'),
-    url('https://assets.holaluz.com/fonts/ciutadella/Ci1001-SmBd.svg#str-replace(%22Ciutadella%22,%20%22%20%22,%20%22_%22)')
-      format('svg');
+      format('woff');
 }
 
 @font-face {
   font-family: Ciutadella;
   font-style: italic;
   font-display: swap;
-  src: url(https://assets.holaluz.com/fonts/ciutadella/Ci1001-RgIt.eot)
-      format('eot'),
-    url(https://assets.holaluz.com/fonts/ciutadella/Ci1001-RgIt.woff2)
+  src: url(https://assets.holaluz.com/fonts/ciutadella/Ci1001-RgIt.woff2)
       format('woff2'),
     url(https://assets.holaluz.com/fonts/ciutadella/Ci1001-RgIt.woff)
-      format('woff'),
-    url(https://assets.holaluz.com/fonts/ciutadella/Ci1001-RgIt.ttf)
-      format('truetype'),
-    url('https://assets.holaluz.com/fonts/ciutadella/Ci1001-RgIt.svg#str-replace(%22Ciutadella%22,%20%22%20%22,%20%22_%22)')
-      format('svg');
+      format('woff');
 }
 
 html,


### PR DESCRIPTION
Let's not have fonts for browsers that we do not support.

![image](https://user-images.githubusercontent.com/4160121/113301434-4c56ba00-92ff-11eb-8fa5-786d394038eb.png)
Source: https://medium.com/@aitareydesign/understanding-of-font-formats-ttf-otf-woff-eot-svg-e55e00a1ef2