### PR TITLE
feat: Add size and tone props to ma-option

### DIFF
--- a/src/components/MaOption/MaOption.spec.js
+++ b/src/components/MaOption/MaOption.spec.js
@@ -115,6 +115,23 @@ describe('Option', () => {
       expect(emitted().change).toHaveLength(2)
       expect(emitted().change[1][0]).toStrictEqual(false)
     })
+    test(`'tone' property assigns the provided style to text`, () => {
+      const { getByText } = renderComponent({
+        tone: 'gray',
+      })
+
+      expect(getByText(SLOT_TEXT)).toHaveStyle({ color: 'rgb(118, 118, 118)' }) //jest converts hex colors to rgb
+    })
+    test(`'size' property assigns the valid provided size styles to text`, () => {
+      const { getByText } = renderComponent({
+        size: 'medium',
+      })
+
+      expect(getByText(SLOT_TEXT)).toHaveStyle({
+        'font-size': '1.125rem',
+        'line-height': '1.35',
+      })
+    })
   })
 })
 

--- a/src/components/MaOption/MaOption.stories.js
+++ b/src/components/MaOption/MaOption.stories.js
@@ -1,5 +1,6 @@
 import MaOption from './MaOption'
 import docs from '../../../docs/components/MaOption.docs.mdx'
+import { tones } from '@margarita/tokens'
 
 export default {
   title: 'Components/Option',
@@ -12,6 +13,18 @@ export default {
       control: false,
     },
     change: { action: 'change' },
+    size: {
+      control: {
+        type: 'select',
+        options: ['xsmall', 'small', 'medium'],
+      },
+    },
+    tone: {
+      control: {
+        type: 'select',
+        options: Object.keys(tones),
+      },
+    },
   },
   parameters: {
     docs: { page: docs },

--- a/src/components/MaOption/MaOption.vue
+++ b/src/components/MaOption/MaOption.vue
@@ -10,7 +10,7 @@
       v-bind="$attrs"
     />
     <span class="indicator" />
-    <ma-text size="small" class="description">
+    <ma-text class="description" :tone="tone" :size="size">
       <slot />
     </ma-text>
   </label>
@@ -18,6 +18,7 @@
 
 <script>
 import uuid from '@margarita/utils/uuid'
+import { tones } from '../../tokens'
 
 /**
  * Renders a radio or checkbox component following the Design System guidelines
@@ -82,6 +83,23 @@ export default {
       default: 'radio',
       validator: (v) => ['radio', 'checkbox'].includes(v),
     },
+    /**
+     * Sets the label element color tone
+     * @values white, red, pink, blue, green, yellow, gray-darker, gray-dark, gray
+     */
+    tone: {
+      type: String,
+      default: 'gray-dark',
+      validator: (val) => Object.keys(tones).includes(val),
+    },
+    /**
+     * Sets the size of the component
+     */
+    size: {
+      default: 'small',
+      type: String,
+      validator: (value) => ['xsmall', 'small', 'medium'].includes(value),
+    },
   },
 
   computed: {
@@ -104,6 +122,7 @@ export default {
 
     computedClass() {
       return {
+        [`ma-selector-${this.size}`]: this.size,
         'ma-selector-card': this.card,
         'ma-option': !this.card,
         [`ma-option--${this.type}`]: !this.card,

--- a/src/components/MaOption/MaOptionCheckbox.css
+++ b/src/components/MaOption/MaOptionCheckbox.css
@@ -18,20 +18,14 @@
   padding-left: calc(var(--indicator-size) + 0.5rem);
   color: var(--color-gray-dark);
 }
-.ma-selector-xsmall {
-  &.ma-option--checkbox .description {
-    margin-top: 4px;
-  }
+.ma-selector-xsmall.ma-option--checkbox .description {
+  margin-top: 4px;
 }
-.ma-selector-small {
-  &.ma-option--checkbox .description {
-    margin-top: 3px;
-  }
+.ma-selector-small.ma-option--checkbox .description {
+  margin-top: 3px;
 }
-.ma-selector-medium {
-  &.ma-option--checkbox .description {
-    margin-top: 2px;
-  }
+.ma-selector-medium.ma-option--checkbox .description {
+  margin-top: 2px;
 }
 
 .ma-option--checkbox .input {

--- a/src/components/MaOption/MaOptionCheckbox.css
+++ b/src/components/MaOption/MaOptionCheckbox.css
@@ -16,8 +16,22 @@
 .ma-option--checkbox .description {
   /* .indicator is absolute-positioned. We need to make room for the text */
   padding-left: calc(var(--indicator-size) + 0.5rem);
-  margin-top: 2px;
   color: var(--color-gray-dark);
+}
+.ma-selector-xsmall {
+  &.ma-option--checkbox .description {
+    margin-top: 4px;
+  }
+}
+.ma-selector-small {
+  &.ma-option--checkbox .description {
+    margin-top: 3px;
+  }
+}
+.ma-selector-medium {
+  &.ma-option--checkbox .description {
+    margin-top: 2px;
+  }
 }
 
 .ma-option--checkbox .input {

--- a/src/components/MaOption/MaOptionRadio.css
+++ b/src/components/MaOption/MaOptionRadio.css
@@ -10,9 +10,23 @@
   height: 1rem;
   user-select: none;
 }
+.ma-selector-xsmall {
+  &.ma-option--radio .description {
+    margin-top: 4px;
+  }
+}
+.ma-selector-small {
+  &.ma-option--radio .description {
+    margin-top: 3px;
+  }
+}
+.ma-selector-medium {
+  &.ma-option--radio .description {
+    margin-top: 2px;
+  }
+}
 
 .ma-option--radio .description {
-  margin-top: 2px;
   padding-left: 0.5rem;
 }
 

--- a/src/components/MaOption/MaOptionRadio.css
+++ b/src/components/MaOption/MaOptionRadio.css
@@ -10,20 +10,14 @@
   height: 1rem;
   user-select: none;
 }
-.ma-selector-xsmall {
-  &.ma-option--radio .description {
-    margin-top: 4px;
-  }
+.ma-selector-xsmall.ma-option--radio .description {
+  margin-top: 4px;
 }
-.ma-selector-small {
-  &.ma-option--radio .description {
-    margin-top: 3px;
-  }
+.ma-selector-small.ma-option--radio .description {
+  margin-top: 3px;
 }
-.ma-selector-medium {
-  &.ma-option--radio .description {
-    margin-top: 2px;
-  }
+.ma-selector-medium.ma-option--radio .description {
+  margin-top: 2px;
 }
 
 .ma-option--radio .description {

--- a/vetur/attributes.json
+++ b/vetur/attributes.json
@@ -262,6 +262,26 @@
     "description": "Sets element's input type",
     "options": ["radio", "checkbox"]
   },
+  "ma-option/tone": {
+    "type": "string",
+    "description": "Sets the label element color tone",
+    "options": [
+      "white",
+      "red",
+      "pink",
+      "blue",
+      "green",
+      "yellow",
+      "gray-darker",
+      "gray-dark",
+      "gray"
+    ]
+  },
+  "ma-option/size": {
+    "type": "string",
+    "description": "Sets the size of the component",
+    "options": ["xsmall", "small", "medium"]
+  },
   "ma-pagination/buttonsNumber": {
     "type": "number",
     "description": "Sets the amount of page buttons' to be displayed"

--- a/vetur/tags.json
+++ b/vetur/tags.json
@@ -57,7 +57,16 @@
     "description": "Renders a modal component following the Design System guidelines\n\n[Component's API documentation](https://holaluz.github.io/margarita/?path=/story/components-modal--modal)"
   },
   "ma-option": {
-    "attributes": ["v-model", "id", "value", "disabled", "card", "type"],
+    "attributes": [
+      "v-model",
+      "id",
+      "value",
+      "disabled",
+      "card",
+      "type",
+      "tone",
+      "size"
+    ],
     "description": "Renders a radio or checkbox component following the Design System guidelines\n\n[Radio's component API documentation](https://holaluz.github.io/margarita/?path=/story/components-option--radio)\n[Checkbox's component API documentation](https://holaluz.github.io/margarita/?path=/story/components-option--checkbox)"
   },
   "ma-pagination": {


### PR DESCRIPTION
These two props solve the text alignment issue in call me component. 
![image](https://user-images.githubusercontent.com/51370533/114200921-f5339380-9955-11eb-9401-27c7eba0bb45.png)

Cause for an specific size text will be a margin-top to align the text with the checkbox.


Current issue in kali:

We are duplicating the ma-text component in call me, the first one is being used by the ma-option and the second one is being used to apply size and tone. The second one is making issues with the positioning so with this PR we could remove one