### PR TITLE
feat(MaText): Set P as default value for MaText' tag

### DIFF
--- a/src/components/MaText/MaText.vue
+++ b/src/components/MaText/MaText.vue
@@ -17,7 +17,7 @@ export default {
      */
     tag: {
       type: String,
-      default: 'span',
+      default: 'p',
       validator: (val) => ['p', 'span', 'label'].includes(val),
     },
 


### PR DESCRIPTION
I do believe setting a `p` as a default element for MaText is the "expected" value when using the component. I'm not entirely sure why we decided to go with a `span` element to start with (maybe because a "text" is not the same thing as a "paragraph"?) but I still believe this change is an improvement.

---

Now, this is a breaking change. What do you think is the scope for it? Fixing it is as simple as removing `tag="p"` from MaText, and adding `tag="span"` on MaTexts without the prop.