### PR TITLE
feat: Update alert styling and remove size prop

### DIFF
--- a/docs/components/MaAlert.docs.mdx
+++ b/docs/components/MaAlert.docs.mdx
@@ -1,3 +1,68 @@
 # Alert
 
-This is the documentation section about Alert component
+## Description
+
+Alerts provide relevant information to the user without impeding their task. Alerts are system generated and may or may not result from a user’s action.
+
+## How to use it?
+
+### Placement
+
+- **Page-level:** Place an alert at the top of a page, directly below the navigation bar and above the breadcrumbs, when it refers to something that happened at the page level.
+- **In-page:** Place an alert within a section of the page when the message is specific to that content.
+
+### Content
+
+The hierarchy of information for all kind of alerts should be:
+
+- What is happening
+- The scope and/or seriousness
+- Which actions have to be taken
+
+The alert's anatomy is formed by: 
+
+- **Title** is important, but not mandatory. Nevertheless, if you use a title ensure that this is the most important information you can give to a user (people scan, don't read).
+- **Text** is always mandatory. Try to be short, use plain language, and stick to the point. When possible, research which message is the most important for your user when using alerts.
+- **Icon** is always mandatory and it's defined by the alert type. It gives the user a visual clue of the meaning, and it's especially important for users with visual impairments.
+
+## When to use it
+
+Use an alert component when we need to inform the user about something thats happening in the system or as a result of his/her actions.
+
+When using this component always select the type of alert with a «user-first» approach. For example, something can be a success for the system and a warning for the user.
+
+
+- ### Warning:
+    Caution the user that their attention or action may be needed within the current context. Use when they're about to do something destructive or when the result of an action is unexpected (but isn't an error).
+
+
+- ### Success:
+    This alert make it obvious to the user that their interaction (sometimes in a different location within the application) with the system has been successful.
+
+    **Example:**
+    When a sign-up has been successful or a form has been sent.
+
+
+- ### Info:
+    It lets the user know that something happened in the system. It provides the user with supplemental information  in regards to the current context or action they are about to take.
+
+    **Example:**
+    When we remind the user that she can access Zona Clientes to get his MGM (/el-efecto-cadena/).
+
+
+- ### Error:
+    Inform the user that their attention is needed to address or be aware of a critical issue in the system that relates to the current context. The message should help them out and give directions to solve the error (if possible).
+
+    **Example:**
+    When a form input (for example, postcode or e-mail) is filled incorrectly. 
+
+
+## Behavior
+
+### Overflow and Resizing
+
+Alert component width is defined by its parent. The responsiveness of the component is managed by its parent.
+
+### Trigger
+
+Alerts can be triggered as a result of an action or can be placed as a fixed element in the page.

--- a/src/components/MaAlert/MaAlert.css
+++ b/src/components/MaAlert/MaAlert.css
@@ -59,3 +59,33 @@
   --alert-background-color: var(--color-yellow-light);
   --alert-icon: url('../../assets/icons/warning.svg');
 }
+
+.alert-banner--error a,
+.alert-banner--info a,
+.alert-banner--success a,
+.alert-banner--warning a {
+  text-decoration: underline;
+}
+
+.alert-banner--error a:hover,
+.alert-banner--info a:hover,
+.alert-banner--success a:hover,
+.alert-banner--warning a:hover {
+  text-decoration: none;
+}
+
+.alert-banner--error a {
+  color: var(--color-red-base);
+}
+
+.alert-banner--info a {
+  color: var(--color-blue-base);
+}
+
+.alert-banner--success a {
+  color: var(--color-green-base);
+}
+
+.alert-banner--warning a {
+  color: var(--color-pink-base);
+}

--- a/src/components/MaAlert/MaAlert.css
+++ b/src/components/MaAlert/MaAlert.css
@@ -1,4 +1,4 @@
-.alert-banner {
+.alert {
   --alert-border-color: none;
   --alert-background-color: none;
   --alert-icon: none;
@@ -10,7 +10,7 @@
   padding: 1rem;
 }
 
-.alert-banner__icon {
+.icon {
   display: block;
   margin-right: 1rem;
   background-repeat: no-repeat;
@@ -21,56 +21,56 @@
   background-image: var(--alert-icon);
 }
 
-.alert-banner--error {
+.alert--error {
   --alert-border-color: var(--color-red-base);
   --alert-background-color: var(--color-red-light);
   --alert-icon: url('../../assets/icons/alert-error.svg');
 }
 
-.alert-banner--info {
+.alert--info {
   --alert-border-color: var(--color-blue-base);
   --alert-background-color: var(--color-blue-light);
   --alert-icon: url('../../assets/icons/info.svg');
 }
 
-.alert-banner--success {
+.alert--success {
   --alert-border-color: var(--color-green-base);
   --alert-background-color: var(--color-green-light);
   --alert-icon: url('../../assets/icons/rounded-tick.svg');
 }
 
-.alert-banner--warning {
+.alert--warning {
   --alert-border-color: var(--color-yellow-dark);
   --alert-background-color: var(--color-yellow-light);
   --alert-icon: url('../../assets/icons/warning.svg');
 }
 
-.alert-banner--error a,
-.alert-banner--info a,
-.alert-banner--success a,
-.alert-banner--warning a {
+.alert--error a,
+.alert--info a,
+.alert--success a,
+.alert--warning a {
   text-decoration: underline;
 }
 
-.alert-banner--error a:hover,
-.alert-banner--info a:hover,
-.alert-banner--success a:hover,
-.alert-banner--warning a:hover {
+.alert--error a:hover,
+.alert--info a:hover,
+.alert--success a:hover,
+.alert--warning a:hover {
   text-decoration: none;
 }
 
-.alert-banner--error a {
+.alert--error a {
   color: var(--color-red-base);
 }
 
-.alert-banner--info a {
+.alert--info a {
   color: var(--color-blue-base);
 }
 
-.alert-banner--success a {
+.alert--success a {
   color: var(--color-green-base);
 }
 
-.alert-banner--warning a {
+.alert--warning a {
   color: var(--color-pink-base);
 }

--- a/src/components/MaAlert/MaAlert.css
+++ b/src/components/MaAlert/MaAlert.css
@@ -7,6 +7,7 @@
   color: var(--color-gray-darker);
   border: 1px solid var(--alert-border-color);
   background-color: var(--alert-background-color);
+  padding: 1rem;
 }
 
 .alert-banner__icon {
@@ -18,22 +19,6 @@
   min-width: 1rem;
   height: 1rem;
   background-image: var(--alert-icon);
-}
-
-.alert-banner--small {
-  padding: 0.5rem;
-}
-
-.alert-banner--small .alert-banner__icon {
-  margin-right: 0.5rem;
-}
-
-.alert-banner--medium {
-  padding: 1rem;
-}
-
-.alert-banner--large {
-  padding: 1.5rem;
 }
 
 .alert-banner--error {

--- a/src/components/MaAlert/MaAlert.spec.js
+++ b/src/components/MaAlert/MaAlert.spec.js
@@ -50,6 +50,6 @@ describe('Alert', () => {
       props: { type: 'error' },
     })
 
-    expect(container.firstChild).toHaveClass('alert-banner--error')
+    expect(container.firstChild).toHaveClass('alert--error')
   })
 })

--- a/src/components/MaAlert/MaAlert.stories.js
+++ b/src/components/MaAlert/MaAlert.stories.js
@@ -23,12 +23,6 @@ export default {
         options: ['success', 'info', 'warning', 'error'],
       },
     },
-    size: {
-      control: {
-        type: 'select',
-        options: ['small', 'medium', 'large'],
-      },
-    },
   },
   parameters: {
     docs: { page: docs },
@@ -37,7 +31,7 @@ export default {
 const Template = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   template: `
-    <ma-alert v-bind="$props"/>
+    <ma-alert v-bind="$props" />
   `,
 })
 

--- a/src/components/MaAlert/MaAlert.vue
+++ b/src/components/MaAlert/MaAlert.vue
@@ -1,6 +1,6 @@
 <template>
-  <div :class="['alert-banner', `alert-banner--${type}`]">
-    <span class="alert-banner__icon" />
+  <div :class="['alert', `alert--${type}`]">
+    <span class="icon" />
     <ma-stack space="xsmall">
       <ma-text v-if="title" bold size="medium" v-text="title" />
       <!-- @slot Alert content slot (Overwrites `text` when both are specified ) -->

--- a/src/components/MaAlert/MaAlert.vue
+++ b/src/components/MaAlert/MaAlert.vue
@@ -2,10 +2,10 @@
   <div :class="['alert-banner', getClasses]">
     <span class="alert-banner__icon" />
     <ma-stack space="xsmall">
-      <ma-heading v-if="title" size="xsmall" v-text="title" />
+      <ma-text v-if="title" bold size="medium" v-text="title" />
       <!-- @slot Alert content slot (Overwrites `text` when both are specified ) -->
       <slot>
-        <ma-text tag="p" v-text="text" />
+        <ma-text size="small" v-text="text" />
       </slot>
     </ma-stack>
   </div>
@@ -13,7 +13,6 @@
 
 <script>
 import MaStack from '@margarita/components/MaStack'
-import MaHeading from '@margarita/components/MaHeading'
 import MaText from '@margarita/components/MaText'
 
 /**
@@ -27,7 +26,6 @@ export default {
 
   components: {
     MaStack,
-    MaHeading,
     MaText,
   },
 

--- a/src/components/MaAlert/MaAlert.vue
+++ b/src/components/MaAlert/MaAlert.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="['alert-banner', getClasses]">
+  <div :class="['alert-banner', `alert-banner--${type}`]">
     <span class="alert-banner__icon" />
     <ma-stack space="xsmall">
       <ma-text v-if="title" bold size="medium" v-text="title" />
@@ -60,12 +60,6 @@ export default {
       default: 'info',
       validator: (value) =>
         ['error', 'info', 'success', 'warning'].includes(value),
-    },
-  },
-
-  computed: {
-    getClasses() {
-      return [`alert-banner--${this.size}`, `alert-banner--${this.type}`]
     },
   },
 }

--- a/src/components/MaAlert/MaAlert.vue
+++ b/src/components/MaAlert/MaAlert.vue
@@ -31,14 +31,6 @@ export default {
 
   props: {
     /**
-     * Sets the size of the component
-     */
-    size: {
-      default: 'medium',
-      type: String,
-      validator: (value) => ['small', 'medium', 'large'].includes(value),
-    },
-    /**
      * Inner text of the component
      */
     text: {

--- a/vetur/attributes.json
+++ b/vetur/attributes.json
@@ -1,9 +1,4 @@
 {
-  "ma-alert/size": {
-    "type": "string",
-    "description": "Sets the size of the component",
-    "options": ["small", "medium", "large"]
-  },
   "ma-alert/text": {
     "type": "string",
     "description": "Inner text of the component"

--- a/vetur/tags.json
+++ b/vetur/tags.json
@@ -1,6 +1,6 @@
 {
   "ma-alert": {
-    "attributes": ["size", "text", "title", "type"],
+    "attributes": ["text", "title", "type"],
     "description": "Renders an alert component following the Design System guidelines\n\n[Component's API documentation](https://holaluz.github.io/margarita/?path=/story/components-alert--alert)"
   },
   "ma-button": {


### PR DESCRIPTION
After a [design review, new updates related to styling](https://www.figma.com/file/7RhweKibaUnxX6WYBl7zKW/Design-System?node-id=5314%3A1401) are coming:

- Title font-size -> 20px
- Body font-size -> 16px
- Link styling (depending on alert type, underlined by default, not underlined in hover)
- Remove alert size prop:
    - Type prop would be removed.
    - Default size would be current medium. (It only affects to padding size)
- Add new doc