### PR TITLE
fix: Add gap support for older browsers

### DIFF
--- a/src/components/MaColumns/MaColumns.spec.js
+++ b/src/components/MaColumns/MaColumns.spec.js
@@ -10,12 +10,12 @@ describe('MaColumns', () => {
 
   test('adds spacing styles', () => {
     const { contentWrapper } = renderComponent({ gap: 'large' })
-    expect(contentWrapper).toHaveStyle({ gap: spacing.large })
+    expect(contentWrapper).toHaveStyle({ '--column-gap': spacing.large })
   })
 
   test('adds spacing styles from array', () => {
     const { contentWrapper } = renderComponent({ gap: ['small', 'large'] })
-    expect(contentWrapper).toHaveStyle({ gap: spacing.small })
+    expect(contentWrapper).toHaveStyle({ '--column-gap': spacing.small })
   })
 
   test('adds justify styles', () => {

--- a/src/components/MaColumns/MaColumns.vue
+++ b/src/components/MaColumns/MaColumns.vue
@@ -82,7 +82,7 @@ export default {
   render(createElement, { parent, props, slots, data }) {
     const gap = getResponsiveGap({ parent, gap: props.gap })
     const columns = getResponsiveColumns({ parent, columns: props.columns })
-    const style = { gap }
+    const style = { '--column-gap': gap }
 
     if (!hasAutoFlow({ columns })) {
       style.gridTemplateColumns = getGridTemplateColumns({ gap, columns })
@@ -171,6 +171,8 @@ function validateColumnsProp(columns) {
 <style lang="postcss">
 .ma-columns {
   display: grid;
+  gap: var(--column-gap);
+
   &.has-auto-flow {
     grid-auto-flow: column;
   }

--- a/src/components/MaStack/MaStack.spec.js
+++ b/src/components/MaStack/MaStack.spec.js
@@ -6,13 +6,13 @@ describe('Stack', () => {
   test('adds spacing classes', () => {
     const { contentWrapper } = renderComponent({ space: 'large' })
 
-    expect(contentWrapper).toHaveStyle({ gap: spacing.large })
+    expect(contentWrapper).toHaveStyle({ '--stack-gap': spacing.large })
   })
 
   test('adds spacing classes from array', () => {
     const { contentWrapper } = renderComponent({ space: ['small', 'large'] })
 
-    expect(contentWrapper).toHaveStyle({ gap: spacing.small })
+    expect(contentWrapper).toHaveStyle({ '--stack-gap': spacing.small })
   })
 
   test('adds alignment classes', () => {

--- a/src/components/MaStack/MaStack.vue
+++ b/src/components/MaStack/MaStack.vue
@@ -82,7 +82,7 @@ export default {
     const componentData = {
       staticClass: 'ma-stack',
       style: {
-        gap: space,
+        '--stack-gap': space,
         justifyItems: align,
       },
     }
@@ -100,5 +100,6 @@ export default {
 .ma-stack {
   display: grid;
   grid-auto-flow: row;
+  gap: var(--stack-gap);
 }
 </style>


### PR DESCRIPTION
Closes #388.

With this change, postcss is able to detect the `gap` property and add the appropriate fallback for shitty browsers:

![imatge](https://user-images.githubusercontent.com/9197791/116536515-4f849c00-a8e5-11eb-9d0b-a71d89e87f20.png)
_(screenshot from dist/margarita.css)_