### PR TITLE
docs: add figma embed color to docs

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -12,7 +12,7 @@ export const parameters = {
     storySort: {
       order: [
         'Introduction',
-        ['Welcome', 'Getting Started', 'Design System'],
+        ['Welcome', 'Getting Started', 'Design Principles', 'Color System'],
         'Tokens',
         'Layout',
         'Components',

--- a/docs/introduction/color-system.stories.mdx
+++ b/docs/introduction/color-system.stories.mdx
@@ -1,0 +1,106 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import { color } from '../../src/tokens/'
+
+
+
+<Meta title="Introduction/Color System" />
+
+# Color Palette Description:
+
+
+### Primary color
+
+- **Pink-base:** Holaluz corporative primary colour. It's used as accent color for interactive elements and call to action buttons.
+- **Pink-dark:** Holaluz coporative pink darker version. This color is normally used to show different states of interactive elements (such as hover and active).
+- **Pink-light:** Holaluz coporative pink lighter version. This color is normally used to show different states of interactive elements (such as hover and active).
+
+### ⬛️  Gray scale
+
+- **Gray-darker:** Blackest gray. This color is used for paragraphs, headings and icon shapes. This can also be used as background, but it must be justified.
+- **Gray-dark:** Color used for text paragraphs, headings and icon shapes. It's also used in footers.
+- **Gray-base:** Color used as muted text, as disabled state in very much all elements. Can also be used as icon color.
+- **Gray-light:** This color is used as line separators, box-borders, section backgrounds, and icon backgrounds. Do not use as text-color for long paragraphs, only for large titles.
+- **Gray-lighter:** Lightest gray. Color used as page background.
+- **White:** Color used for backgrounds and text over dark backgrounds.
+
+### 🟩  Green scale
+
+**Green-Energy Gradient Colors**
+
+- **Turquoise-base:** This color is part of the "100% Green Energy" badge, and can only be used when talking about green energy in texts, icons, borders or the “100% energía verde” badge.
+- **Green-dark:** This color is part of the "100% Green Energy" gradient, and can only be used when talking about green energy in texts, icons, borders or the “100% energía verde” badge.
+
+**Success Feedback Colors**
+
+- **Green-base:** Use this color to give feedback to the user when something is or has gone successfully. Apply it to plain text, text inside a positive alert and icons.
+- **Green-light:** Use this color to give feedback to the user when something is or has gone successfully. Apply it to alert background and, sporadically, illustrations.
+
+### 🟦  Blue scale
+
+**Information Feedback Colors**
+
+- Blue-base: Use this color to give feedback to the user when something needs information. Apply it to plain text, text inside a positive alert, and icons.
+- Blue-light: Use this color to give feedback to the user when something needs information. Apply it to plain text, text inside a positive alert, and icons.
+
+### 🟥  Red scale
+
+**Error Feedback Colors**
+
+- Red-base: Use this color to give the user feedback when something is gone wrong or has errors. Apply it to plain text, text inside a positive alert, box-borders, inputs, and icons.
+- Red-light
+
+### 🟨  Yellow scale
+
+**HL-Gradient colors**
+
+- **Orange-base:** This color is part of the gradient and CANNOT be used for any other reason.
+- **Yellow-dark:** This color is part of the gradient and CANNOT be used for any other reason.
+
+**Warning Feedback Color**
+
+- **Yellow-base:** Use this color to give feedback to the user when something is warning or has gone not good but not bad. Apply it to plain text, text inside a positive alert and icons.
+- **Yellow-light:** Use this color to give feedback to the user when something is warning or has gone not good but not bad. Apply it to alert background and, sporadically, illustrations.
+
+### 🟫  Brown scale
+
+- **Brown-base:** Color used on shadows (fancy).
+- **Brown-light:** Color used as page and layout components background.
+
+### Holaluz Gradient
+
+Corporative gradient of Holaluz. Use this color for emphasise an interactive element inside a screen. It will have more importance than the primary color (pink-base). Think about it like a super primary.
+
+This color also can be used decoratively: to make section breaks, headers, box borders, and text style.
+
+A little story: This gradient has 3 colors because we wanted to pass accesibilty when putting white text on it. So we invented 2 new colors for the color palette in order to pass AA score. Don't hate us.
+
+### Green Energy Gradient
+
+This is the "Green Energy" gradient of Holaluz. We don't use it as part of the interface colors because it is more part of the brand.
+
+It can be used as background for headers and sections, text style and as an icon color when the context is about Green Energy.
+
+
+
+
+
+
+
+# Usage guidelines
+
+Please make sure all texts and icons have a proper contrast with background color so they accessible.
+
+### Accent colors
+
+pink-base, pink-dark, pink-light
+<iframe
+    width='600'
+    height='250'
+    src='https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2F7RhweKibaUnxX6WYBl7zKW%2FDesign-System%3Fnode-id%3D5774%253A4337%20'>
+</iframe>
+
+
+### Colors for texts
+
+pink-base, gray-darker, gray-dark, gray-base, red-base, green-base, blue-base, turquoise-base, HL gradient
+

--- a/docs/introduction/color-system.stories.mdx
+++ b/docs/introduction/color-system.stories.mdx
@@ -1,106 +1,13 @@
-import { Meta } from '@storybook/addon-docs/blocks';
+import { Meta, Story } from '@storybook/addon-docs/blocks';
 import { color } from '../../src/tokens/'
 
 
 
 <Meta title="Introduction/Color System" />
 
-# Color Palette Description:
-
-
-### Primary color
-
-- **Pink-base:** Holaluz corporative primary colour. It's used as accent color for interactive elements and call to action buttons.
-- **Pink-dark:** Holaluz coporative pink darker version. This color is normally used to show different states of interactive elements (such as hover and active).
-- **Pink-light:** Holaluz coporative pink lighter version. This color is normally used to show different states of interactive elements (such as hover and active).
-
-### ⬛️  Gray scale
-
-- **Gray-darker:** Blackest gray. This color is used for paragraphs, headings and icon shapes. This can also be used as background, but it must be justified.
-- **Gray-dark:** Color used for text paragraphs, headings and icon shapes. It's also used in footers.
-- **Gray-base:** Color used as muted text, as disabled state in very much all elements. Can also be used as icon color.
-- **Gray-light:** This color is used as line separators, box-borders, section backgrounds, and icon backgrounds. Do not use as text-color for long paragraphs, only for large titles.
-- **Gray-lighter:** Lightest gray. Color used as page background.
-- **White:** Color used for backgrounds and text over dark backgrounds.
-
-### 🟩  Green scale
-
-**Green-Energy Gradient Colors**
-
-- **Turquoise-base:** This color is part of the "100% Green Energy" badge, and can only be used when talking about green energy in texts, icons, borders or the “100% energía verde” badge.
-- **Green-dark:** This color is part of the "100% Green Energy" gradient, and can only be used when talking about green energy in texts, icons, borders or the “100% energía verde” badge.
-
-**Success Feedback Colors**
-
-- **Green-base:** Use this color to give feedback to the user when something is or has gone successfully. Apply it to plain text, text inside a positive alert and icons.
-- **Green-light:** Use this color to give feedback to the user when something is or has gone successfully. Apply it to alert background and, sporadically, illustrations.
-
-### 🟦  Blue scale
-
-**Information Feedback Colors**
-
-- Blue-base: Use this color to give feedback to the user when something needs information. Apply it to plain text, text inside a positive alert, and icons.
-- Blue-light: Use this color to give feedback to the user when something needs information. Apply it to plain text, text inside a positive alert, and icons.
-
-### 🟥  Red scale
-
-**Error Feedback Colors**
-
-- Red-base: Use this color to give the user feedback when something is gone wrong or has errors. Apply it to plain text, text inside a positive alert, box-borders, inputs, and icons.
-- Red-light
-
-### 🟨  Yellow scale
-
-**HL-Gradient colors**
-
-- **Orange-base:** This color is part of the gradient and CANNOT be used for any other reason.
-- **Yellow-dark:** This color is part of the gradient and CANNOT be used for any other reason.
-
-**Warning Feedback Color**
-
-- **Yellow-base:** Use this color to give feedback to the user when something is warning or has gone not good but not bad. Apply it to plain text, text inside a positive alert and icons.
-- **Yellow-light:** Use this color to give feedback to the user when something is warning or has gone not good but not bad. Apply it to alert background and, sporadically, illustrations.
-
-### 🟫  Brown scale
-
-- **Brown-base:** Color used on shadows (fancy).
-- **Brown-light:** Color used as page and layout components background.
-
-### Holaluz Gradient
-
-Corporative gradient of Holaluz. Use this color for emphasise an interactive element inside a screen. It will have more importance than the primary color (pink-base). Think about it like a super primary.
-
-This color also can be used decoratively: to make section breaks, headers, box borders, and text style.
-
-A little story: This gradient has 3 colors because we wanted to pass accesibilty when putting white text on it. So we invented 2 new colors for the color palette in order to pass AA score. Don't hate us.
-
-### Green Energy Gradient
-
-This is the "Green Energy" gradient of Holaluz. We don't use it as part of the interface colors because it is more part of the brand.
-
-It can be used as background for headers and sections, text style and as an icon color when the context is about Green Energy.
-
-
-
-
-
-
-
-# Usage guidelines
-
-Please make sure all texts and icons have a proper contrast with background color so they accessible.
-
-### Accent colors
-
-pink-base, pink-dark, pink-light
 <iframe
-    width='600'
-    height='250'
-    src='https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2F7RhweKibaUnxX6WYBl7zKW%2FDesign-System%3Fnode-id%3D5774%253A4337%20'>
+    width='100%'
+    height= '1000px'
+    src='https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Fproto%2F7RhweKibaUnxX6WYBl7zKW%2FDesign-System%3Fnode-id%3D5315%253A10889%26scaling%3Dscale-down-width%26page-id%3D5314%253A0%26hotspot-hints%3D0%26hide-ui%3D1'>
 </iframe>
-
-
-### Colors for texts
-
-pink-base, gray-darker, gray-dark, gray-base, red-base, green-base, blue-base, turquoise-base, HL gradient
 


### PR DESCRIPTION
This PR is to test the figma embeds in our docs.

You can se the example in the **Introduction category** --> **Color System** (you will need to scroll down)

Process:

To get the correct link we need to group the elements we want to show in FIGMA. Otherwise, the embed will show all the page.

Will be interesting to  confirm that url created in FIGMA will remain exactly the same after the Figma release

Please share your opinions :)
