### PR TITLE
fix: MaOption set span as default tag

### DIFF
--- a/src/components/MaList/MaList.stories.js
+++ b/src/components/MaList/MaList.stories.js
@@ -12,18 +12,6 @@ export default {
         options: ['bullet', 'check', 'ordered'],
       },
     },
-    tone: {
-      control: {
-        type: 'select',
-        options: Object.keys(tones),
-      },
-    },
-    size: {
-      control: {
-        type: 'select',
-        options: ['small', 'medium'],
-      },
-    },
   },
   parameters: {
     docs: { page: docs },
@@ -34,9 +22,9 @@ const Template = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   template: `
     <ma-list v-bind="$props">
-      <ma-text tag="p">Item 1</ma-text>
-      <ma-text tag="p" tone="pink">Item 2</ma-text>
-      <ma-text tag="p">Item 3 <a href="">here</a></ma-text>
+      <ma-text>Item 1</ma-text>
+      <ma-text tone="pink">Item 2</ma-text>
+      <ma-text>Item 3 <a href="">here</a></ma-text>
     </ma-list>
   `,
 })

--- a/src/components/MaList/MaList.stories.js
+++ b/src/components/MaList/MaList.stories.js
@@ -1,6 +1,5 @@
 import MaList from './MaList'
 import docs from '../../../docs/components/MaList.docs.mdx'
-import { tones } from '@margarita/tokens'
 
 export default {
   title: 'Components/List',

--- a/src/components/MaOption/MaOption.vue
+++ b/src/components/MaOption/MaOption.vue
@@ -10,7 +10,7 @@
       v-bind="$attrs"
     />
     <span class="indicator" />
-    <ma-text class="description" :tone="tone" :size="size">
+    <ma-text tag="span" class="description" :tone="tone" :size="size">
       <slot />
     </ma-text>
   </label>


### PR DESCRIPTION
Related to https://github.com/holaluz/margarita/issues/409

Hello all,

I guess after setting the tag="p" in ma-text as default the maOption is broken when you try to align img + text (please see the image below). This pr is to fix it.

![image](https://user-images.githubusercontent.com/51370533/116999700-467a3d00-ace0-11eb-8252-50b8dc437ac8.png)
