### PR TITLE
feat(MaCard): Remove has-padding-top from

### DIFF
--- a/src/components/MaCard/MaCard.css
+++ b/src/components/MaCard/MaCard.css
@@ -10,7 +10,3 @@
   box-shadow: 0 0 6px 2px var(--shadow-light);
   background-color: var(--color-white-base);
 }
-
-.ma-card--has-padding-top {
-  padding-top: 1.5rem;
-}

--- a/src/components/MaCard/MaCard.vue
+++ b/src/components/MaCard/MaCard.vue
@@ -1,8 +1,6 @@
 <template>
-  <div :class="{ 'ma-card--has-padding-top': hasPaddingTop }">
-    <div :class="`ma-card--${color}`" class="ma-card">
-      <slot />
-    </div>
+  <div :class="`ma-card--${color}`" class="ma-card">
+    <slot />
   </div>
 </template>
 
@@ -24,14 +22,6 @@ export default {
       type: String,
       default: 'gray',
       validator: (val) => ['white', 'gray'].includes(val),
-    },
-
-    /**
-     * Sets card's top padding
-     */
-    hasPaddingTop: {
-      type: Boolean,
-      default: false,
     },
   },
 }

--- a/vetur/attributes.json
+++ b/vetur/attributes.json
@@ -39,10 +39,6 @@
     "description": "Sets card background color",
     "options": ["white", "gray"]
   },
-  "ma-card/hasPaddingTop": {
-    "type": "boolean",
-    "description": "Sets card's top padding"
-  },
   "ma-columns/columns": {
     "type": "array|string",
     "description": "Defines the columns layout.\n\n```ts\n<ma-column columns=\"6 6\">...</ma-column>\n<ma-column :columns=\"['12', '4 4 4', '6 6']\">...</ma-column>\n```"

--- a/vetur/tags.json
+++ b/vetur/tags.json
@@ -8,7 +8,7 @@
     "description": "Renders a button or link element following the Design System guidelines\n\n[Component's API documentation](https://holaluz.github.io/margarita/?path=/story/components-button--button)"
   },
   "ma-card": {
-    "attributes": ["color", "hasPaddingTop"],
+    "attributes": ["color"],
     "description": "Renders a card component following the Design System guidelines\n\n[Component's API documentation](https://holaluz.github.io/margarita/?path=/story/components-card--card)"
   },
   "ma-columns": {


### PR DESCRIPTION
As now we have Ma-Layout and Ma-Stack we don't need the `has-padding-top` anymore, so this PR removes the prop to prevent its usage.

It's a breaking change, but a "little" one, it's only used 9 times only in Bonasera.

I'm not sure how to tag this release, fix with breaking change in the comment to release a major version?