### PR TITLE
fix: scope styles in MaAlert 

### DIFF
--- a/src/components/MaAlert/MaAlert.vue
+++ b/src/components/MaAlert/MaAlert.vue
@@ -57,4 +57,4 @@ export default {
 }
 </script>
 
-<style src="./MaAlert.css"></style>
+<style scoped src="./MaAlert.css"></style>

--- a/src/components/MaOption/MaOption.vue
+++ b/src/components/MaOption/MaOption.vue
@@ -10,7 +10,7 @@
       v-bind="$attrs"
     />
     <span class="indicator" />
-    <ma-text tag="span" class="description" :tone="tone" :size="size">
+    <ma-text class="description" :tone="tone" :size="size">
       <slot />
     </ma-text>
   </label>


### PR DESCRIPTION
Hi all,
This PR is to scope the styles from Ma-alert #401  because we are overlapping other component styles (as the RadioQuestions commented on the [issue before](https://github.com/holaluz/margarita/issues/409)). Also, I removed the tag defined previously to fix the MaOption because is not doing anything it should be solved with this fix.