### PR TITLE
fix(MaTextField): Allow using disabled as prop

### DIFF
--- a/src/components/MaTextField/MaTextField.vue
+++ b/src/components/MaTextField/MaTextField.vue
@@ -21,6 +21,7 @@
         v-bind="$attrs"
         class="ma-text-field__input"
         :class="inputClasses"
+        :disabled="disabled"
         v-on="inputListeners"
         @keyup.enter="removeFocus"
       />
@@ -113,6 +114,13 @@ export default {
       default: false,
     },
     /**
+     * Disables the input element
+     */
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+    /**
      * Component's model value
      * @model
      */
@@ -143,7 +151,7 @@ export default {
 
     inputWrapperClasses() {
       return {
-        'ma-text-field__input-wrapper--disabled': this.$attrs.disabled,
+        'ma-text-field__input-wrapper--disabled': this.disabled,
         'ma-text-field__input--error': this.hasError,
       }
     },

--- a/vetur/attributes.json
+++ b/vetur/attributes.json
@@ -463,6 +463,10 @@
     "type": "boolean",
     "description": "Applies bold weigth to label"
   },
+  "ma-text-field/disabled": {
+    "type": "boolean",
+    "description": "Disables the input element"
+  },
   "ma-text-field/v-model": {
     "type": "string|number",
     "description": "Component's model value"

--- a/vetur/tags.json
+++ b/vetur/tags.json
@@ -119,6 +119,7 @@
       "label",
       "tone",
       "bold",
+      "disabled",
       "v-model",
       "suffix"
     ],


### PR DESCRIPTION
Looks like passing attrs does not allow us to simply set `<ma-text-field disabled>`, only `:disabled="true"`, because otherwise it does not append the `.ma-text-field__input-wrapper--disabled` class. With the proposed fix, both of these options work:

```vue
<ma-text-field disabled />
<ma-text-field :disabled="true" />
```

