### PR TITLE
docs: add-ma-card-docs

### DIFF
--- a/docs/components/MaCard.docs.mdx
+++ b/docs/components/MaCard.docs.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story } from '@storybook/addon-docs/blocks'
+import { Meta } from '@storybook/addon-docs/blocks'
 
 <Meta title="Components/Card" />
 

--- a/docs/components/MaCard.docs.mdx
+++ b/docs/components/MaCard.docs.mdx
@@ -1,3 +1,9 @@
-# Card
+import { Meta, Story } from '@storybook/addon-docs/blocks'
 
-This is the documentation section about Card component
+<Meta title="Components/Card" />
+
+<iframe
+  width="100%"
+  height="1000px"
+  src="https://www.figma.com/proto/7RhweKibaUnxX6WYBl7zKW/%E2%9A%A1%EF%B8%8F-Watt-Design-System?embed_host=share&hotspot-hints=0&kind=&node-id=5664%3A338&page-id=5314%3A1402&scaling=scale-down-width&viewport=1280%2C446%2C0.48540157079696655&hide-ui=1"
+></iframe>

--- a/src/components/MaCard/MaCard.spec.js
+++ b/src/components/MaCard/MaCard.spec.js
@@ -22,9 +22,9 @@ describe('Card', () => {
   })
 })
 
-function renderComponent(props) {
+function renderComponent(props = {}) {
   const utils = render(MaCard, {
-    props: { ...props },
+    props,
     slots: { default: 'content' },
   })
   const contentWrapper = utils.getByText('content')

--- a/src/components/MaCard/MaCard.spec.js
+++ b/src/components/MaCard/MaCard.spec.js
@@ -1,0 +1,35 @@
+import { render } from '@margarita/margarita-test-utils'
+import MaCard from './MaCard'
+
+describe('Card', () => {
+  test('renders a card element by default', () => {
+    const { contentWrapper } = renderComponent()
+    expect(contentWrapper).toBeVisible()
+  })
+
+  test('renders the default grey variant when we do not specify the prop color', () => {
+    const { contentWrapper } = renderComponent()
+
+    expect(contentWrapper).toHaveClass('ma-card--gray')
+  })
+
+  test('renders the white variant when we specify the white prop color', () => {
+    const { contentWrapper } = renderComponent({
+      color: 'white',
+    })
+
+    expect(contentWrapper).toHaveClass('ma-card--white')
+  })
+})
+
+function renderComponent(props) {
+  const utils = render(MaCard, {
+    props: { ...props },
+    slots: { default: 'content' },
+  })
+  const contentWrapper = utils.getByText('content')
+  return {
+    ...utils,
+    contentWrapper,
+  }
+}


### PR DESCRIPTION
### Summary
Add emded docs for MaCard component from Figma. I've also added some basic tests. It is related to [this](https://holaluz.kanbanize.com/ctrl_board/65/cards/23083/details/) Kanbanize card.

### Resources
- [Link en Figma](https://www.figma.com/proto/7RhweKibaUnxX6WYBl7zKW/%E2%9A%A1%EF%B8%8F-Watt-Design-System?embed_host=share&hotspot-hints=0&kind=&node-id=5664%3A338&page-id=5314%3A1402&scaling=scale-down-width&viewport=1280%2C446%2C0.48540157079696655&hide-ui=1)
- [Docu en Notion](https://www.notion.so/holaluz/a1cb451d360941d98f08831cf679edab?v=f7024af195d34caface8649e58f98c12&p=c50116a66ba844b7b3398abcdb0088da)