### PR TITLE
[PoC] MaForm

### DIFF
--- a/src/components/MaForm/MaForm.stories.js
+++ b/src/components/MaForm/MaForm.stories.js
@@ -1,0 +1,55 @@
+import MaForm from './MaForm'
+import * as validators from './_validators/validators'
+
+export default {
+  title: 'Components/Form',
+  component: MaForm,
+}
+
+const Template = (args, { argTypes }) => ({
+  props: Object.keys(argTypes),
+  computed: {
+    validators() {
+      return validators
+    },
+  },
+  data() {
+    return {
+      name: '',
+      email: '',
+      phone: '',
+      isSubmitted: false,
+    }
+  },
+  methods: {
+    onSubmit() {
+      this.isSubmitted = true
+      setTimeout(() => {
+        this.isSubmitted = false
+      }, 2000)
+    },
+  },
+  template: `<ma-form @submit="onSubmit" style="width: 300px">
+    <ma-stack space="medium">
+      <ma-form-field
+        label="Full name"
+        v-model="name"
+        :validators="[validators.isRequired]"
+      />
+      <ma-form-field
+        label="Email address"
+        v-model="email"
+        :validators="[validators.isRequired, validators.isEmail]"
+      />
+      <ma-form-field
+        label="Phone number"
+        v-model="phone"
+        :validators="[validators.isRequired, validators.isPhoneNumber]"
+      />
+      <ma-button type="submit">Submit</ma-button>
+      <ma-alert v-if="isSubmitted" tone="green">Form submitted successfully!</ma-alert>
+    </ma-stack>
+  </ma-form>`,
+})
+
+export const Form = Template.bind({})

--- a/src/components/MaForm/MaForm.vue
+++ b/src/components/MaForm/MaForm.vue
@@ -13,13 +13,6 @@ export default {
         (c) => c.$options._componentTag === maTextTag && c.hasError
       )
     },
-    submitElement() {
-      const maButtonTag = 'ma-button'
-      return this.$children.find(
-        (c) =>
-          c.$options._componentTag === maButtonTag && c.$attrs.type === 'submit'
-      )
-    },
   },
   methods: {
     onSubmit() {

--- a/src/components/MaForm/MaForm.vue
+++ b/src/components/MaForm/MaForm.vue
@@ -1,0 +1,39 @@
+<template>
+  <form ref="formElement" @submit.prevent="onSubmit">
+    <slot />
+  </form>
+</template>
+
+<script>
+export default {
+  computed: {
+    inputFieldsWithError() {
+      const maTextTag = 'ma-form-field'
+      return this.$children.filter(
+        (c) => c.$options._componentTag === maTextTag && c.hasError
+      )
+    },
+    submitElement() {
+      const maButtonTag = 'ma-button'
+      return this.$children.find(
+        (c) =>
+          c.$options._componentTag === maButtonTag && c.$attrs.type === 'submit'
+      )
+    },
+  },
+  methods: {
+    onSubmit() {
+      if (this.inputFieldsWithError.length) {
+        this.inputFieldsWithError.forEach((i) => {
+          i.hasBeenBlurred = true
+        })
+        this.inputFieldsWithError[0].$el.scrollIntoView({ behavior: 'smooth' })
+      } else {
+        this.$emit('submit')
+      }
+    },
+  },
+}
+</script>
+
+<style></style>

--- a/src/components/MaForm/_components/MaFormField.vue
+++ b/src/components/MaForm/_components/MaFormField.vue
@@ -1,0 +1,73 @@
+<template>
+  <ma-text-field
+    v-model="model"
+    :placeholder="placeholder ? placeholder : label"
+    :has-error="!!errorMessage"
+    :error-message="errorMessage"
+    :label="label"
+    @focus="onFocus"
+    @blur="onBlur"
+  />
+</template>
+
+<script>
+export default {
+  props: {
+    value: {
+      type: [String, Number],
+      required: true,
+    },
+    label: {
+      type: String,
+      required: true,
+    },
+    placeholder: {
+      type: String,
+      default: '',
+    },
+    validators: {
+      type: Array,
+      default: () => [],
+    },
+  },
+  data() {
+    return {
+      isFocused: false,
+      hasBeenBlurred: false,
+    }
+  },
+  computed: {
+    errorMessages() {
+      return this.validators
+        .map((validator) => validator(this.model))
+        .filter((v) => v)
+    },
+    hasError() {
+      return !!this.errorMessages.length
+    },
+    errorMessage() {
+      if (this.isFocused || !this.hasBeenBlurred || !this.hasError) return ''
+      const [errorMessage] = this.errorMessages
+      if (this.$t) return this.$t(errorMessage)
+      return errorMessage
+    },
+    model: {
+      get() {
+        return this.value
+      },
+      set(value) {
+        this.$emit('input', value)
+      },
+    },
+  },
+  methods: {
+    onBlur() {
+      this.hasBeenBlurred = true
+      this.isFocused = false
+    },
+    onFocus() {
+      this.isFocused = true
+    },
+  },
+}
+</script>

--- a/src/components/MaForm/_components/MaFormField.vue
+++ b/src/components/MaForm/_components/MaFormField.vue
@@ -1,21 +1,27 @@
 <template>
-  <ma-text-field
+  <component
+    :is="component"
     v-model="model"
-    v-bind="$attrs"
+    v-bind="{ ...$attrs, ...$props }"
     :placeholder="placeholder ? placeholder : label"
     :has-error="!!errorMessage"
     :error-message="errorMessage"
     :label="label"
-    @focus="onFocus"
     @blur="onBlur"
-  />
+    >{{ label }}</component
+  >
 </template>
 
 <script>
 export default {
   props: {
+    type: {
+      type: String,
+      validator: (v) => ['text', 'radio', 'checkbox', 'select'].includes(v),
+      default: 'text',
+    },
     value: {
-      type: [String, Number],
+      type: [String, Number, Boolean],
       required: true,
     },
     label: {
@@ -33,11 +39,21 @@ export default {
   },
   data() {
     return {
-      isFocused: false,
       hasBeenBlurred: false,
     }
   },
   computed: {
+    component() {
+      switch (this.type) {
+        case 'radio':
+          return 'MaOption'
+        case 'checkbox':
+          return 'MaOption'
+        case 'select':
+          return 'MaSelect'
+      }
+      return 'MaTextField'
+    },
     errorMessages() {
       return this.validators
         .map((validator) => validator(this.model))
@@ -47,7 +63,7 @@ export default {
       return !!this.errorMessages.length
     },
     errorMessage() {
-      if (this.isFocused || !this.hasBeenBlurred || !this.hasError) return ''
+      if (!this.hasBeenBlurred || !this.hasError) return ''
       const [errorMessage] = this.errorMessages
       if (this.$t) return this.$t(errorMessage)
       return errorMessage
@@ -64,10 +80,6 @@ export default {
   methods: {
     onBlur() {
       this.hasBeenBlurred = true
-      this.isFocused = false
-    },
-    onFocus() {
-      this.isFocused = true
     },
   },
 }

--- a/src/components/MaForm/_components/MaFormField.vue
+++ b/src/components/MaForm/_components/MaFormField.vue
@@ -1,6 +1,7 @@
 <template>
   <ma-text-field
     v-model="model"
+    v-bind="$attrs"
     :placeholder="placeholder ? placeholder : label"
     :has-error="!!errorMessage"
     :error-message="errorMessage"

--- a/src/components/MaForm/_validators/validators.js
+++ b/src/components/MaForm/_validators/validators.js
@@ -1,0 +1,11 @@
+export const isRequired = (value) => (value ? '' : 'error-required')
+
+export const isEmail = (value) => {
+  const isEmailValidEx = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
+  return isEmailValidEx.test(value.toLowerCase()) ? '' : 'error-email-invalid'
+}
+
+export const isPhoneNumber = (value) => {
+  const isPhoneValidEx = /^[6789]{1}[0-9]{8}$/g
+  return isPhoneValidEx.test(value) ? '' : 'error-phone-invalid'
+}

--- a/src/components/MaForm/examples/example-form.vue
+++ b/src/components/MaForm/examples/example-form.vue
@@ -1,17 +1,21 @@
 <template>
-  <ma-form class="form" @submit="onSubmit">
-    <ma-stack space="medium">
-      <slot />
-      <ma-button type="submit">Submit</ma-button>
-      <ma-alert v-if="isSubmitted" tone="green">
-        Form submitted successfully!
-      </ma-alert>
-    </ma-stack>
-  </ma-form>
+  <div class="container">
+    <ma-form class="form" @submit="onSubmit">
+      <ma-stack space="medium">
+        <slot />
+        <ma-button type="submit">Submit</ma-button>
+        <ma-alert v-if="isSubmitted" tone="green">
+          Form submitted successfully!
+        </ma-alert>
+      </ma-stack>
+    </ma-form>
+  </div>
 </template>
 
 <script>
+import MaStack from '@/components/MaStack/MaStack.vue'
 export default {
+  components: { MaStack },
   data() {
     return {
       isSubmitted: false,
@@ -27,9 +31,20 @@ export default {
   },
 }
 </script>
-
 <style scoped>
+.container {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
 .form {
-  width: 300px;
+  max-width: 500px;
+  width: 100%;
 }
 </style>

--- a/src/components/MaForm/examples/example-form.vue
+++ b/src/components/MaForm/examples/example-form.vue
@@ -1,0 +1,35 @@
+<template>
+  <ma-form class="form" @submit="onSubmit">
+    <ma-stack space="medium">
+      <slot />
+      <ma-button type="submit">Submit</ma-button>
+      <ma-alert v-if="isSubmitted" tone="green">
+        Form submitted successfully!
+      </ma-alert>
+    </ma-stack>
+  </ma-form>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      isSubmitted: false,
+    }
+  },
+  methods: {
+    onSubmit() {
+      this.isSubmitted = true
+      setTimeout(() => {
+        this.isSubmitted = false
+      }, 2000)
+    },
+  },
+}
+</script>
+
+<style scoped>
+.form {
+  width: 300px;
+}
+</style>

--- a/src/components/MaForm/examples/examples.stories.js
+++ b/src/components/MaForm/examples/examples.stories.js
@@ -5,7 +5,7 @@ export default {
   title: 'Components/Form/examples',
 }
 
-export const RepeatPasswordValidation = () => ({
+export const ComplexFormExample = () => ({
   components: { ExampleForm },
   computed: {
     validators() {
@@ -14,27 +14,96 @@ export const RepeatPasswordValidation = () => ({
   },
   data() {
     return {
-      password: '',
-      repeatPassword: '',
+      firstName: '',
+      lastName: '',
+      email: '',
+      repeatEmail: '',
+      gender: '',
+      country: '',
+      // I don't like this
+      reasonFriend: false,
+      reasonAd: false,
+      reasonOther: false,
+      step: 'monthly',
     }
   },
   methods: {
     validateRepeat(value) {
-      return this.password === value ? '' : 'error-mismatch'
+      return this.email === value ? '' : 'error-mismatch'
+    },
+    atLeastOne() {
+      return this.reasonAd || this.reasonFriend || this.reasonOther
+        ? ''
+        : 'error-choose-at-least-one'
     },
   },
   template: `
     <example-form>
+    <ma-layout columns="6 6 - 6 6 - 12" gap="medium">
       <ma-form-field
-        label="Password"
-        v-model="password"
+        label="First Name"
+        v-model="firstName"
         :validators="[validators.isRequired]"
       />
       <ma-form-field
-        label="Repeat password"
-        v-model="repeatPassword"
-        :validators="[validators.isRequired, validateRepeat]"
+        label="Last Name"
+        v-model="lastName"
+        :validators="[validators.isRequired]"
       />
+      <ma-form-field
+        label="Email"
+        v-model="email"
+        :validators="[validators.isRequired, validators.isEmail]"
+      />
+      <ma-form-field
+        label="Repeat Email"
+        v-model="repeatEmail"
+        :validators="[validators.isRequired,  validators.isEmail, validateRepeat]"
+      />
+      <ma-form-field
+        label="Gender"
+        v-model="gender"
+        type="select"
+        :options="[{ label: 'Female', value: 'female'}, { label: 'Male', value: 'male' }, { label: 'Other', value: 'other' }]"
+        :validators="[validators.isRequired]"
+      />
+      <ma-form-field
+        label="Country"
+        v-model="country"
+        type="select"
+        :options="[{ label: 'Spain', value: 'spain'}, { label: 'Russia', value: 'russia' }]"
+        :validators="[validators.isRequired]"
+      />
+      <ma-text size="small">How did you know us?</ma-text>
+      <ma-form-field
+        label="From a friend"
+        v-model="reasonFriend"
+        type="checkbox"
+        :validators="[atLeastOne]"
+      />
+      <ma-form-field
+        label="From an ad"
+        v-model="reasonAd"
+        type="checkbox"
+        :validators="[atLeastOne]"
+      />
+      <ma-form-field
+        label="Other"
+        v-model="reasonOther"
+        type="checkbox"
+        :validators="[atLeastOne]"
+      />
+      <ma-range
+        label="How often do you use our App?" 
+        v-model="step"
+        :steps="[
+          { text: 'Once a month', value: 'monthly' },
+          { text: 'Every other week', value: 'biweekly' },
+          { text: 'Every week', value: 'weekly' },
+          { text: 'Every day', value: 'daily' },
+        ]"
+      />
+      </ma-layout>
     </example-form>
   `,
 })
@@ -57,7 +126,7 @@ export const FormGroupExample = () => ({
   },
   template: `
     <example-form>
-      <ma-layout columns="6 6" gap="small">
+      <ma-layout columns="6 6" gap="medium">
         <ma-form-field
           v-for="(power, i) in powers"
           :label="'Power ' + i"

--- a/src/components/MaForm/examples/examples.stories.js
+++ b/src/components/MaForm/examples/examples.stories.js
@@ -1,0 +1,71 @@
+import * as validators from '../_validators/validators'
+import ExampleForm from './example-form.vue'
+
+export default {
+  title: 'Components/Form/examples',
+}
+
+export const RepeatPasswordValidation = () => ({
+  components: { ExampleForm },
+  computed: {
+    validators() {
+      return validators
+    },
+  },
+  data() {
+    return {
+      password: '',
+      repeatPassword: '',
+    }
+  },
+  methods: {
+    validateRepeat(value) {
+      return this.password === value ? '' : 'error-mismatch'
+    },
+  },
+  template: `
+    <example-form>
+      <ma-form-field
+        label="Password"
+        v-model="password"
+        :validators="[validators.isRequired]"
+      />
+      <ma-form-field
+        label="Repeat password"
+        v-model="repeatPassword"
+        :validators="[validators.isRequired, validateRepeat]"
+      />
+    </example-form>
+  `,
+})
+
+export const FormGroupExample = () => ({
+  components: { ExampleForm },
+  data() {
+    return {
+      powers: [0, 0, 0, 0, 0, 0],
+    }
+  },
+  methods: {
+    powerValidator(minValue) {
+      return (v) => {
+        if (v < 15000) return 'Value should be greater than 15000'
+        if (v <= minValue) return `Value should be greater than ${minValue}`
+        return ''
+      }
+    },
+  },
+  template: `
+    <example-form>
+      <ma-layout columns="6 6" gap="small">
+        <ma-form-field
+          v-for="(power, i) in powers"
+          :label="'Power ' + i"
+          v-model="powers[i]"
+          type="number"
+          :validators="[powerValidator(i ? powers[i-1] : 0)]"
+        />
+      </ma-layout>
+    </example-form>
+  `,
+})

--- a/src/components/MaSelect/MaSelect.vue
+++ b/src/components/MaSelect/MaSelect.vue
@@ -14,6 +14,7 @@
       v-bind="$attrs"
       :class="computedClass"
       class="ma-select__field"
+      @blur="$emit('blur', $event)"
     >
       <option
         v-for="(option, index) in formattedOptions"

--- a/src/components/MaTextField/MaTextField.css
+++ b/src/components/MaTextField/MaTextField.css
@@ -43,7 +43,7 @@
 
 .ma-text-field__input {
   flex: 0 1 100%;
-  transition: border 0.2s ease;
+  transition: border 0.3s ease;
   padding: 0 0.5rem;
   width: 100%;
   height: 100%;
@@ -82,8 +82,8 @@
   background-image: url('../../assets/icons/alert-error.svg');
   background-position: calc(100% - 8px) center;
   background-repeat: no-repeat;
-  background-size: 20px;
   padding-right: 2.5rem;
+  animation: zoomIn 0.3s forwards;
 }
 
 .ma-text-field__input--error:focus,
@@ -95,4 +95,26 @@
   margin-top: 0.25rem;
   color: var(--color-red-base);
   font-size: 0.875rem;
+  opacity: 0;
+  animation: fadeIn 0.5s forwards;
+}
+
+@keyframes zoomIn {
+  from {
+    background-size: 0;
+  }
+  to {
+    background-size: 20px;
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(-20%);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,8 @@ export {
   MaList,
   MaHeading,
   MaLink,
+  MaForm,
+  MaFormField,
   markdown,
   markdownSSR,
   responsivePlugin,

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,8 @@ import MaList from './components/MaList'
 import MaStack from './components/MaStack'
 import MaHeading from './components/MaHeading'
 import MaLink from './components/MaLink'
+import MaForm from './components/MaForm/MaForm.vue'
+import MaFormField from './components/MaForm/_components/MaFormField.vue'
 import { markdown, markdownSSR } from './directives/markdown'
 import responsivePlugin from './plugins/responsivePlugin'
 
@@ -72,6 +74,8 @@ function install(Vue) {
   Vue.component('MaText', MaText)
   Vue.component('MaTextField', MaTextField)
   Vue.component('MaList', MaList)
+  Vue.component('MaForm', MaForm)
+  Vue.component('MaFormField', MaFormField)
 
   Vue.directive('markdown', markdown)
 }

--- a/vetur/tags.json
+++ b/vetur/tags.json
@@ -23,6 +23,10 @@
     "attributes": ["rows", "columns", "isLoading", "noResultsText"],
     "description": "Renders a datagrid component following the Design System guidelines\n\n[Component's API documentation](https://holaluz.github.io/margarita/?path=/story/components-datagrid--datagrid)"
   },
+  "ma-form": {
+    "attributes": [],
+    "description": ""
+  },
   "ma-heading": {
     "attributes": ["level", "size", "tone", "align"],
     "description": "Renders heading following the Design System guidelines\n\n[Component's API documentation](https://holaluz.github.io/margarita/?path=/story/components-heading--heading)"


### PR DESCRIPTION
Hello! This is just a proof of concept to see if my idea was feasible or not. The code is super rushed and probably could be way better written, but let's focus on the main idea to see if you like it or not.

## What is this?

Basically is a way to streamline form validation and form UX so that all of our forms work the same way. I tried to do the simplest, most general solution I could think of in order to see if all of our use cases would fit in it. That's why I ended up not adding any dependency, since sometimes we use vuelidate, sometimes veevalidate, sometimes nothing. And honestly, after checking it for a while I don't see a real necessity to use one or another (let's debate it tho!).

## What does this do?

This tries to solve some problems I found we have with our forms:
 - The forms do not submit when pressing enter.
 - We normally disable the submit button when there is an incorrect field. This is bad UX, we should let the user press it and then show the incorrect field.
 - The form validations are handled differently in every project. There is no way of sharing validators between projects. Some of the form validations contain side effects that are hard to maintain.
 - There is a lot of boilerplate in order to create a working form. We have to manually do basic UX stuff that should be done by margarita directly (for example, not showing error messages if an input is focused or pristine).

And so far it solves all of them. Maybe there are stuff other projects need that are not reflected in here, so let's talk it.

## How do we do it

This introduces three concepts:
 -  **MaForm**: a root form element that handles the validation of the whole form. Aka "a group of `MaFormFields`".
 -  **MaFormField**: handles validations of an input element. Basically, a wrapper of `MaTextField` that validates on blur and shows/hides the validation message when the user is writing or when the input element has not been touched.
 - **Validator**: a function that receives a value and returns `''` if the value is correct, or an error key `errror-whatever` if the input is incorrect. That error key will be the one we use to show error messages in i18n.

### Example

This proof of concept renders this form:

![image](https://user-images.githubusercontent.com/4160121/129580232-23af5014-445b-4a71-90d5-06dd9a17a330.png)

The basic markup/API is this:

```vue
<template>
<ma-form @submit="onSubmit">
    <ma-stack space="medium">
      <ma-form-field
        label="Full name"
        v-model="name"
        :validators="[validators.isRequired]"
      />
      <ma-form-field
        label="Email address"
        v-model="email"
        :validators="[validators.isRequired, validators.isEmail]"
      />
      <ma-form-field
        label="Phone number"
        v-model="phone"
        :validators="[validators.isRequired, validators.isPhoneNumber]"
      />
      <ma-button type="submit">Submit</ma-button>
    </ma-stack>
  </ma-form>
</template>
<script>
import * as validators from '@margarita/validators'

export default {
 computed: {
    validators() {
      return validators
    },
  },
  data() {
    return {
      name: '',
      email: '',
      phone: '',
    }
  },
  methods: {
    onSubmit() {
      // sending stuff to core or wherever is needed. This will only execute when all form fields are valid.
    },
  },
}
</script>
```

Please, try the [deploy preview](https://601199d127273f0021b037b0-fmtmrbzalg.chromatic.com/?path=/story/components-form--form) because most of the stuff discussed here is hard to describe if you don't see it in person. If you have any question of how I did it, it's pretty stupid. Basically `MaForm` is searching for `MaFormFields` in its children and checking whether they are invalid or not. If the `MaForm` has any child that is invalid it won't emit a submit button, it will just scroll to the first input with an error.

## Caveats

There are some stuff that this can't do, even though I don't think it would be specially difficult to add:
 - Async validators. For example, validations that have to check things in core.
 - The way of importing validators is a bit meh because we can't use them directly in the template, we have to use a computed. Maybe `validators` could accept a string and let `ma-form-field` handle the import.
 - This only validates `ma-text-fields`. Adding other fields would require extending the `ma-form-field` wrapper. I think there is no problem with `ma-select`, for example. But things like `ma-option` start being a bit weird, since we don't have an "invalid state" for them.
 - Full-form validations. That is, validations that happen AFTER we press submit. In my mind makes sense to just do them in the component that renders the `ma-form` because what we do after we press submit might vary depending on the use case. A good example for this is the use case I used for this proof of concept: "saving a lead". The lead email can be non-deliverable, but we will only know that if core returns a 400. So for example, we can show a message under the `ma-text-field` of the email if we submit an incorrect email without having to implement extra stuff:

```vue
<template>
<ma-form @submit="saveLead">
    <!-- we add a custom validator "isEmailDeliverable" -->
     <ma-form-field :validators"[isRequired, isEmail, isEmailDeliverableValidator]" ... />
</template>

<script>
...
  methods: {
     async saveLead() {
           try { await core.saveLead(...)}
           catch { this.isEmailDeliverable = false }
     },
     isEmailDeliverableValidator() {
         return this.isEmailDeliverable ? '' : 'error-email-non-deliverable' 
     }
  }
```

## Stuff I think would be nice to add after reading about form UX

- Animations to the validation messages. Maybe we improve the UX if the validation icon and text has some kind of movement.
- "Check" markers if fields are correct. Maybe marking the fields that are filled correctly would improve UX too.
- A "toast" message if we try to send an invalid form, not only rely on the input error messages to show errors.


What do you think? Can you think of any use case where this is completely unusable? Or some important feature this thing does not fix? Any comment would be amazing 😃 