### PR TITLE
[PoC] Accessible disabled ma-text-field

### DIFF
--- a/src/components/MaTextField/MaTextField.css
+++ b/src/components/MaTextField/MaTextField.css
@@ -35,10 +35,9 @@
   border: 1px solid var(--color-pink-base);
 }
 
-.ma-text-field__input-wrapper--disabled {
+.ma-text-field__input-wrapper--readonly {
   background-color: var(--color-brown-light);
   color: var(--color-gray-base);
-  pointer-events: none;
 }
 
 .ma-text-field__input {

--- a/src/components/MaTextField/MaTextField.spec.js
+++ b/src/components/MaTextField/MaTextField.spec.js
@@ -41,9 +41,9 @@ describe('TextField', () => {
   })
 
   test('renders a disabled input', () => {
-    const { input } = renderComponent({ disabled: true })
+    const { input } = renderComponent({ readonly: true })
 
-    expect(input).toBeDisabled()
+    expect(input).toHaveAttribute('readonly', 'readonly')
   })
 
   test('renders custom id', () => {

--- a/src/components/MaTextField/MaTextField.vue
+++ b/src/components/MaTextField/MaTextField.vue
@@ -21,7 +21,7 @@
         v-bind="$attrs"
         class="ma-text-field__input"
         :class="inputClasses"
-        :disabled="disabled"
+        :readonly="readonly"
         v-on="inputListeners"
         @keyup.enter="removeFocus"
       />
@@ -114,9 +114,9 @@ export default {
       default: false,
     },
     /**
-     * Disables the input element
+     * Disables the input element but leaves input focusable
      */
-    disabled: {
+    readonly: {
       type: Boolean,
       default: false,
     },
@@ -151,7 +151,7 @@ export default {
 
     inputWrapperClasses() {
       return {
-        'ma-text-field__input-wrapper--disabled': this.disabled,
+        'ma-text-field__input-wrapper--readonly': this.readonly,
         'ma-text-field__input--error': this.hasError,
       }
     },

--- a/vetur/attributes.json
+++ b/vetur/attributes.json
@@ -528,9 +528,9 @@
     "type": "boolean",
     "description": "Applies bold weigth to label"
   },
-  "ma-text-field/disabled": {
+  "ma-text-field/readonly": {
     "type": "boolean",
-    "description": "Disables the input element"
+    "description": "Disables the input element but leaves input focusable"
   },
   "ma-text-field/v-model": {
     "type": "string|number",

--- a/vetur/tags.json
+++ b/vetur/tags.json
@@ -128,7 +128,7 @@
       "label",
       "tone",
       "bold",
-      "disabled",
+      "readonly",
       "v-model",
       "suffix"
     ],


### PR DESCRIPTION
We are having trouble making a form accessible because of the "disabled" ma-text-fields. 

An`<input disabled` does not add a tab stop nor is it focusable. An `<input readonly` adds a tab stop, it's focusable, but it's not writable. [Source](https://medium.com/@izzmo/anti-pattern-using-disabled-or-read-only-for-form-input-e2c24c669f5b).

This problem makes forms like this (address field depends on postal code) unusable, since pressing tab passes from the postal code input directly to the "Tornar enrere" button:

![image](https://user-images.githubusercontent.com/4160121/142223397-38813467-572b-496b-8652-fdf2a859b37b.png)

I think we should stop using `disabled` in favor of `readonly`. What do you think?

Yes. Maybe having internal dependencies between inputs is the problem here. Maybe someone else has a better example 😂 
